### PR TITLE
BUG: does not build with gcc 8.1.0

### DIFF
--- a/ants/lib/LOCAL_antsTransform.h
+++ b/ants/lib/LOCAL_antsTransform.h
@@ -448,79 +448,79 @@ py::capsule matrixOffset(  std::string type, std::string precision, unsigned int
     if ( type == "AffineTransform" )
     {
         typedef itk::AffineTransform<PrecisionType,Dimension> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "CenteredAffineTransform" )
     {
         typedef itk::CenteredAffineTransform<PrecisionType,Dimension> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "Euler3DTransform" )
     {
         typedef itk::Euler3DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "Euler2DTransform" )
     {
         typedef itk::Euler2DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "QuaternionRigidTransform" )
     {
         typedef itk::QuaternionRigidTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "Rigid2DTransform" )
     {
         typedef itk::Rigid2DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "Rigid3DTransform" )
     {
         typedef itk::Rigid3DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "CenteredEuler3DTransform" )
     {
         typedef itk::CenteredEuler3DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "CenteredRigid2DTransform" )
     {
         typedef itk::CenteredRigid2DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "Similarity3DTransform" )
     {
         typedef itk::Similarity3DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "Similarity2DTransform" )
     {
         typedef itk::Similarity2DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else if ( type == "CenteredSimilarity2DTransform" )
     {
         typedef itk::CenteredSimilarity2DTransform<PrecisionType> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
     else
     {
         typedef itk::AffineTransform<PrecisionType,Dimension> TransformType;
-        typename TransformType::Pointer transformPointer = TransformType::New();
+        auto transformPointer = TransformType::New();
         matrixOffset = dynamic_cast<MatrixOffsetBaseType*>( transformPointer.GetPointer() );
     }
 

--- a/ants/lib/LOCAL_readTransform.cxx
+++ b/ants/lib/LOCAL_readTransform.cxx
@@ -86,12 +86,12 @@ template <typename PrecisionType, unsigned int Dimension>
 py::capsule newAntsTransform( std::string precision, unsigned int dimension, std::string type)
 {   
 
-    //typename TransformType::Pointer transformPointer = TransformType::New();
+    //auto transformPointer = TransformType::New();
   // Initialize transform by type
   if ( type == "AffineTransform" )
     {
     typedef itk::AffineTransform<PrecisionType,Dimension> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -102,7 +102,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "CenteredAffineTransform" )
     {
     typedef itk::CenteredAffineTransform<PrecisionType,Dimension> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -113,7 +113,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "Euler3DTransform" )
     {
     typedef itk::Euler3DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -125,7 +125,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "Euler2DTransform" )
     {
     typedef itk::Euler2DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -136,7 +136,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "QuaternionRigidTransform" )
     {
     typedef itk::QuaternionRigidTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -147,7 +147,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "Rigid2DTransform" )
     {
     typedef itk::Rigid2DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -158,7 +158,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "Rigid3DTransform" )
     {
     typedef itk::Rigid3DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -169,7 +169,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "CenteredEuler3DTransform" )
     {
     typedef itk::CenteredEuler3DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -180,7 +180,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "CenteredRigid2DTransform" )
     {
     typedef itk::CenteredRigid2DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -191,7 +191,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "Similarity3DTransform" )
     {
     typedef itk::Similarity3DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -202,7 +202,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "Similarity2DTransform" )
     {
     typedef itk::Similarity2DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -213,7 +213,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
   else if ( type == "CenteredSimilarity2DTransform" )
     {
     typedef itk::CenteredSimilarity2DTransform<PrecisionType> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;
@@ -223,7 +223,7 @@ py::capsule newAntsTransform( std::string precision, unsigned int dimension, std
     }
 
     typedef itk::AffineTransform<PrecisionType,Dimension> TransformType;
-    typename TransformType::Pointer transformPointer = TransformType::New();
+    auto transformPointer = TransformType::New();
 
     typedef itk::Transform<PrecisionType,Dimension,Dimension> TransformBaseType;
     typedef typename TransformBaseType::Pointer               TransformBasePointerType;


### PR DESCRIPTION
When trying to compile with gcc 8.1.0, I got errors like:
```
ants/lib/LOCAL_antsTransform.h:487:41: converting from ”SmartPointer<itk::MatrixOffsetTransformBase<float, 3, 3>>”
                                       to non-scalar type ”SmartPointer<itk::Rigid3DTransform<float>>”
```
Deducing the type of the object automatically, as done with this commit,
avoids the need to convert the object, and should also make the code a
little less verbose.