### PR TITLE
revise ortho plot direction, failed setup from github source

### DIFF
--- a/ants/lib/CMakeLists.txt
+++ b/ants/lib/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.0)
 
 project(ants)
 
-#set(PYBIND11_CPP_STANDARD -std=c++14)
+set(PYBIND11_CPP_STANDARD -std=c++14)
+#add_definitions(-std=c++11)
+add_definitions(-std=c++1y)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 

--- a/ants/viz/plot.py
+++ b/ants/viz/plot.py
@@ -359,7 +359,7 @@ def plot_ortho_stack(images, overlays=None, reorient=True,
     text=None, textfontsize=24, textfontcolor='white', text_dx=0, text_dy=0,
     # save & size arguments
     filename=None, dpi=500, figsize=1., colpad=0, rowpad=0,
-    transpose=False, transparent=True):
+    transpose=False, transparent=True, orient_labels=True):
     """
     Example
     -------
@@ -558,6 +558,27 @@ def plot_ortho_stack(images, overlays=None, reorient=True,
                               [yz_slice.shape[1]-xyz[2],yz_slice.shape[1]-xyz[2]],
                 color=xyz_color, alpha=xyz_alpha, linewidth=xyz_linewidth)
             ax.add_line(l)
+        if orient_labels:
+            ax.text(0.5,0.98, 'S',
+                    horizontalalignment='center',
+                    verticalalignment='top',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.5,0.02, 'I',
+                    horizontalalignment='center',
+                    verticalalignment='bottom',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.98,0.5, 'A',
+                    horizontalalignment='right',
+                    verticalalignment='center',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.02,0.5, 'P',
+                    horizontalalignment='left',
+                    verticalalignment='center',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
         ax.axis('off')
         ####################
         ####################
@@ -581,6 +602,27 @@ def plot_ortho_stack(images, overlays=None, reorient=True,
                               [xz_slice.shape[1]-xyz[2],xz_slice.shape[1]-xyz[2]],
                               color=xyz_color, alpha=xyz_alpha, linewidth=xyz_linewidth)
             ax.add_line(l)
+        if orient_labels:
+            ax.text(0.5,0.98, 'A',
+                    horizontalalignment='center',
+                    verticalalignment='top',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.5,0.02, 'P',
+                    horizontalalignment='center',
+                    verticalalignment='bottom',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.98,0.5, 'L',
+                    horizontalalignment='right',
+                    verticalalignment='center',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.02,0.5, 'R',
+                    horizontalalignment='left',
+                    verticalalignment='center',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
         ax.axis('off')
 
         ####################
@@ -604,6 +646,27 @@ def plot_ortho_stack(images, overlays=None, reorient=True,
                               [xy_slice.shape[1]-xyz[1],xy_slice.shape[1]-xyz[1]],
                               color=xyz_color, alpha=xyz_alpha, linewidth=xyz_linewidth)
             ax.add_line(l)
+        if orient_labels:
+            ax.text(0.5,0.98, 'A',
+                    horizontalalignment='center',
+                    verticalalignment='top',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.5,0.02, 'P',
+                    horizontalalignment='center',
+                    verticalalignment='bottom',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.98,0.5, 'L',
+                    horizontalalignment='right',
+                    verticalalignment='center',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
+            ax.text(0.02,0.5, 'R',
+                    horizontalalignment='left',
+                    verticalalignment='center',
+                    fontsize=20*figsize, color=textfontcolor,
+                    transform=ax.transAxes)
         ax.axis('off')
 
     ####################
@@ -1365,12 +1428,12 @@ def plot_ortho(image, overlay=None, reorient=True, blend=False,
                     verticalalignment='bottom',
                     fontsize=20*figsize, color=textfontcolor,
                     transform=ax.transAxes)
-            ax.text(0.98,0.5, 'R',
+            ax.text(0.98,0.5, 'L',
                     horizontalalignment='right',
                     verticalalignment='center',
                     fontsize=20*figsize, color=textfontcolor,
                     transform=ax.transAxes)
-            ax.text(0.02,0.5, 'L',
+            ax.text(0.02,0.5, 'R',
                     horizontalalignment='left',
                     verticalalignment='center',
                     fontsize=20*figsize, color=textfontcolor,
@@ -1407,12 +1470,12 @@ def plot_ortho(image, overlay=None, reorient=True, blend=False,
                     verticalalignment='bottom',
                     fontsize=20*figsize, color=textfontcolor,
                     transform=ax.transAxes)
-            ax.text(0.98,0.5, 'R',
+            ax.text(0.98,0.5, 'L',
                     horizontalalignment='right',
                     verticalalignment='center',
                     fontsize=20*figsize, color=textfontcolor,
                     transform=ax.transAxes)
-            ax.text(0.02,0.5, 'L',
+            ax.text(0.02,0.5, 'R',
                     horizontalalignment='left',
                     verticalalignment='center',
                     fontsize=20*figsize, color=textfontcolor,

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+export ITK_DIR=/data2/qinqian/MRI/software/ANTsX/ANTs/build/ITKv4-build/
+export VTK_DIR=/data1/qinqian/MRI/software/ANTsX/ANTs/build/VTK-build/
+python setup.py install --user

--- a/setup.py
+++ b/setup.py
@@ -120,8 +120,8 @@ class CMakeBuild(build_ext):
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{} {} -DVERSION_INFO=\\"{}\\"'.format("-Wno-inconsistent-missing-override",
-                                                                    env.get('CXXFLAGS', ''),
-                                                                    self.distribution.get_version())
+                                                                 env.get('CXXFLAGS', ''),
+                                                                 self.distribution.get_version())
         env['LINKFLAGS'] = '{}'.format("-Wno-inconsistent-missing-override")
 
         if not os.path.exists(self.build_temp):


### PR DESCRIPTION
I tried to make a quick fix on issue(the https://github.com/ANTsX/ANTsPy/issues/59). However, I cannot make a thorough test since I cannot use "python setup.py install" to install ANTsPy, I tried to add -std=c++1y and -std=c++11 in cmake file, but neither worked. Previously, I can install ANTsPy by using pip. I am using ANTspy with Ubuntu 16.04 and python3.6. Thanks.