### PR TITLE
Fix typo from PR #66 and add test.

### DIFF
--- a/ants/registration/build_template.py
+++ b/ants/registration/build_template.py
@@ -53,7 +53,7 @@ def build_template(
     if 'type_of_transform' not in kwargs:
         type_of_transform = 'SyN'
     else:
-        type_of_tranform = kwargs.pop('type_of_transform')
+        type_of_transform = kwargs.pop('type_of_transform')
 
     wt = 1.0 / len( image_list )
     if initial_template is None:
@@ -65,7 +65,7 @@ def build_template(
     for i in range( iterations ):
         for k in range( len( image_list ) ):
             w1 = registration( xavg, image_list[k],
-              type_of_transform=type_of_tranform, **kwargs )
+              type_of_transform=type_of_transform, **kwargs )
             if k == 0:
               wavg = iio.image_read( w1['fwdtransforms'][0] ) * wt
               xavgNew = w1['warpedmovout'] * wt

--- a/tests/test_registation.py
+++ b/tests/test_registation.py
@@ -262,6 +262,7 @@ class TestModule_symmetrize_image(unittest.TestCase):
         image = ants.image_read(ants.get_ants_data('r16'))
         simage = ants.symmetrize_image(image)
 
+
 class TestModule_build_template(unittest.TestCase):
 
     def setUp(self):
@@ -274,6 +275,14 @@ class TestModule_build_template(unittest.TestCase):
         image = ants.image_read(ants.get_ants_data('r16'))
         image2 = ants.image_read(ants.get_ants_data('r27'))
         timage = ants.build_template( image_list = (image, image2 ) )
+
+    def test_type_of_transform(self):
+        image = ants.image_read(ants.get_ants_data('r16'))
+        image2 = ants.image_read(ants.get_ants_data('r27'))
+        timage = ants.build_template( image_list = (image, image2 ))
+        timage = ants.build_template( image_list = (image, image2 ),
+                                      type_of_transform='SyNCC')
+
 
 class TestModule_multivar(unittest.TestCase):
 


### PR DESCRIPTION
My bad, just found a typo: "tranform" instead of "transform".