### PR TITLE
Lift 3d restriction to nibabel

### DIFF
--- a/ants/utils/convert_nibabel.py
+++ b/ants/utils/convert_nibabel.py
@@ -1,7 +1,7 @@
 __all__ = ["to_nibabel", "from_nibabel"]
 
 import os
-from tempfile import mktemp
+from tempfile import mkstemp
 import numpy as np
 from ..core import ants_image_io as iio2
 
@@ -11,9 +11,10 @@ def to_nibabel(image):
     Convert an ANTsImage to a Nibabel image
     """
     import nibabel as nib
-    tmpfile = mktemp(suffix=".nii.gz")
+    fd, tmpfile = mkstemp(suffix=".nii.gz")
     image.to_filename(tmpfile)
     new_img = nib.load(tmpfile)
+    os.close(fd)
     # os.remove(tmpfile) ## Don't remove tmpfile as nibabel lazy loads the data.
     return new_img
 
@@ -22,8 +23,9 @@ def from_nibabel(nib_image):
     """
     Convert a nibabel image to an ANTsImage
     """
-    tmpfile = mktemp(suffix=".nii.gz")
+    fd, tmpfile = mkstemp(suffix=".nii.gz")
     nib_image.to_filename(tmpfile)
     new_img = iio2.image_read(tmpfile)
+    os.close(fd)
     os.remove(tmpfile)
     return new_img

--- a/ants/utils/convert_nibabel.py
+++ b/ants/utils/convert_nibabel.py
@@ -10,21 +10,11 @@ def to_nibabel(image):
     """
     Convert an ANTsImage to a Nibabel image
     """
-    if image.dimension != 3:
-        raise ValueError("Only 3D images currently supported")
-
     import nibabel as nib
-
-    array_data = image.numpy()
-    affine = np.hstack(
-        [
-            np.matmul(image.direction, np.diag(image.spacing)),
-            np.array(image.origin).reshape(3, 1),
-        ]
-    )
-    affine = np.vstack([affine, np.array([0, 0, 0, 1.0])])
-    affine[:2, :] *= -1
-    new_img = nib.Nifti1Image(array_data, affine)
+    tmpfile = mktemp(suffix=".nii.gz")
+    image.to_filename(tmpfile)
+    new_img = nib.load(tmpfile)
+    # os.remove(tmpfile) ## Don't remove tmpfile as nibabel lazy loads the data.
     return new_img
 
 


### PR DESCRIPTION
Currently, to_nibabel only accepts 3D images. This PR lifts this restriction.
It also changes the usage of mktemp to the thread safe alternative mkstemp.

Should nibabel also be added to the requirements.txt?