### PR TITLE
Change motion correction default to BOLDRigid.

### DIFF
--- a/ants/registration/interface.py
+++ b/ants/registration/interface.py
@@ -749,7 +749,7 @@ def registration(fixed,
 def motion_correction(
                  image,
                  fixed=None,
-                 type_of_transform="Rigid",
+                 type_of_transform="BOLDRigid",
                  mask=None,
                  fdOffset = 50,
                  verbose = False,


### PR DESCRIPTION
I noticed that simple "Rigid" would sometimes fail generating extremely large "spikes" in the motion corrected series, especially for small FOV datasets.
I haven't (so far) come across the issue after changing the type_of_transform to "BOLDRigid".

Are there any reasons why "BOLDRigid" should not be the default?