### PR TITLE
Add support for colorbar in plot_grid

### DIFF
--- a/ants/viz/plot.py
+++ b/ants/viz/plot.py
@@ -364,7 +364,15 @@ def plot_grid(
     else:
         vmaxs = vmax
 
-    for rowidx, vmin, vmax in zip(range(nrow), vmins, vmaxs):
+    if isinstance(cmap, str):
+        cmaps = [cmap] * nrow
+    elif cmap is None:
+        cmaps = [None] * nrow
+    else:
+        cmaps = cmap
+
+    print(cmaps)
+    for rowidx, vmin, vmax, cmap in zip(range(nrow), vmins, vmaxs, cmaps):
         for colidx in range(ncol):
             ax = plt.subplot(gs[rowidx, colidx])
 

--- a/ants/viz/plot.py
+++ b/ants/viz/plot.py
@@ -350,7 +350,7 @@ def plot_grid(
         right=1 - 0.5 / (ncol + 1),
     )
 
-    if not isinstance(vmin, (int, float)):
+    if isinstance(vmin, (int, float)):
         vmins = [vmin] * nrow
     elif vmin is None:
         vmins = [None] * nrow
@@ -371,8 +371,7 @@ def plot_grid(
     else:
         cmaps = cmap
 
-    print(cmaps)
-    for rowidx, vmin, vmax, cmap in zip(range(nrow), vmins, vmaxs, cmaps):
+    for rowidx, rvmin, rvmax, rcmap in zip(range(nrow), vmins, vmaxs, cmaps):
         for colidx in range(ncol):
             ax = plt.subplot(gs[rowidx, colidx])
 
@@ -445,7 +444,7 @@ def plot_grid(
             sliceidx = slices[rowidx][colidx] if not one_slice else slices
             tmpslice = slice_image(tmpimg, tmpaxis, sliceidx)
             tmpslice = reorient_slice(tmpslice, tmpaxis)
-            im = ax.imshow(tmpslice, cmap=cmap, aspect="auto", vmin=vmin, vmax=vmax)
+            im = ax.imshow(tmpslice, cmap=rcmap, aspect="auto", vmin=rvmin, vmax=rvmax)
             ax.axis("off")
 
         # A colorbar solution with make_axes_locatable will not allow y-scaling of the colorbar.


### PR DESCRIPTION
Example:

```python
import ants
mni1 = ants.image_read(ants.get_data("mni"))
ants.plot_grid([[mni1, mni1],[mni1, mni1]], 
                slices=100, vmax=[5000, 8000], clabels=["mni", "mni"], rlabels=["foo", "bar"])
```

![image](https://user-images.githubusercontent.com/7881842/74202303-f7239900-4c63-11ea-91f5-2490a877c507.png)
