### PR TITLE
Improve viz.plot's input validation

### DIFF
--- a/ants/viz/plot.py
+++ b/ants/viz/plot.py
@@ -2219,6 +2219,8 @@ def plot(
     if not isinstance(image, iio.ANTsImage):
         raise ValueError("image argument must be an ANTsImage")
 
+    assert image.sum() > 0, "Image must be non-zero"
+
     if (image.pixeltype not in {"float", "double"}) or (image.is_rgb):
         scale = False  # turn off scaling if image is discrete
 


### PR DESCRIPTION
There is an implicit assumption in the logic of viz.plot that it's input is
non-zero. While this is a reasonable assumption, calling viz.plot on a
zero-valued array results in an opaque IndexError.

Make the assumption explicit, and fail with the more descriptive AssertionError
"Image must be nonzero".

Resolves: #214