### PR TITLE
ENH: first try of a docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.8.6-buster as builder
+
+# Build specific tag with
+# pip install git+https://github.com/ANTsX/ANTsPy.git@tag 
+#
+# Maybe also reduce container size with
+# pip install git+https://github.com/ANTsX/ANTsPy.git --install-option="--novtk"
+
+RUN apt-get update && \
+    apt-get install -y cmake=3.13.4-1 && \
+    python3 -m venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    pip install wheel && \
+    pip install git+https://github.com/ANTsX/ANTsPy.git && \
+    git clone https://github.com/ANTsX/ANTsPy.git /opt/ANTsPy
+
+FROM python:3.8.5-slim
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=1
+
+# Make a user and add data to the expected location
+RUN useradd --create-home antspyuser && \
+    mkdir /home/antspyuser/.antspy
+
+COPY --from=builder /opt/ANTsPy/data/* /home/antspyuser/.antspy/
+    
+WORKDIR /home/antspyuser
+USER antspyuser
+
+ENTRYPOINT ["python"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+# ANTsPy docker
+
+## ANTsPy build
+
+The latest commit of ANTsPy is built from source. The build arg `antspy_version`
+can be used to build a specific release or commit.
+
+
+## Controlling threads
+
+The default number of threads is 1, override by passing the
+`ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS` variable, eg
+
+```
+docker run -e ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2 ...
+```
+
+
+## Version and dependency information
+
+Run the container with `-m pip freeze` to get version information.


### PR DESCRIPTION
This builds ANTsPy from source using pip. It makes a virtual environment first, which is then copied to the final layer. This makes for a smaller final image.

The base is the official Python Docker images, which are based on Debian.

