### PR TITLE
Update image_similarity.py

### DIFF
--- a/ants/utils/image_similarity.py
+++ b/ants/utils/image_similarity.py
@@ -25,7 +25,7 @@ def image_similarity(fixed_image, moving_image, metric_type='MeanSquares',
         image metric to calculate
             MeanSquares
             Correlation
-            ANTSNeighborhoodCorrelation
+            ANTsNeighborhoodCorrelation
             MattesMutualInformation
             JointHistogramMutualInformation
             Demons


### PR DESCRIPTION
Corrected one typo. If left "ANTSNeighborhoodCorrelation", the algorithm raises an error. Also, it should be corrected in the online documentation (https://antspy.readthedocs.io/en/latest/_modules/ants/utils/image_similarity.html)