### PR TITLE
Fix multi-arch support for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x86_64; elif [ "
     sha256sum -c --ignore-missing cmake-${CMAKE_VERSION}-SHA-256.txt && \
     curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt.asc && \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys C6C265324BBEBDC350B513D02D2CEF1034921684 && \
-    gpg --verify cmake-${CMAKE_VERSION}-SHA-256.txt.asc cmake-${CMAKE_VERSION}-SHA-256.txt
-
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x86_64; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; elif [ "$TARGETPLATFORM" = "linux/ppc64le" ]; then ARCHITECTURE=x86_64; else ARCHITECTURE=x86_64; fi && \
+    gpg --verify cmake-${CMAKE_VERSION}-SHA-256.txt.asc cmake-${CMAKE_VERSION}-SHA-256.txt && \
     mkdir /opt/cmake && \
     chmod +x cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh && \
     ./cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh --skip-license --prefix=/opt/cmake

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,9 @@
 
 # Use conda to resolve dependencies cross-platform
 FROM continuumio/miniconda3:4.11.0 as builder
-ARG TARGETPLATFORM
 
 # install libpng to system for cross-architecture support
 # https://github.com/ANTsX/ANTs/issues/1069#issuecomment-681131938
-# Also install kitware key and get recent cmake
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       apt-transport-https \
@@ -19,22 +17,9 @@ RUN apt-get update && \
       libpng-dev \
       software-properties-common
 
-# Install cmake from binary
+# install cmake binary using conda for multi-arch support
 # apt install fails because libssl1.0.0 is not available for newer Debian
-# Download verification stuff from https://cmake.org/install/
-ARG CMAKE_VERSION=3.23.1
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x86_64; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; elif [ "$TARGETPLATFORM" = "linux/ppc64le" ]; then ARCHITECTURE=x86_64; else ARCHITECTURE=x86_64; fi && \
-    curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt && \
-    curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh && \
-    sha256sum -c --ignore-missing cmake-${CMAKE_VERSION}-SHA-256.txt && \
-    curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt.asc && \
-    gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys C6C265324BBEBDC350B513D02D2CEF1034921684 && \
-    gpg --verify cmake-${CMAKE_VERSION}-SHA-256.txt.asc cmake-${CMAKE_VERSION}-SHA-256.txt && \
-    mkdir /opt/cmake && \
-    chmod +x cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh && \
-    ./cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh --skip-license --prefix=/opt/cmake
-
-ENV PATH=/opt/cmake/bin:${PATH}
+RUN conda install -c anaconda cmake
 
 WORKDIR /usr/local/src
 COPY environment.yml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-# This Dockerfile supports amd64,ppc64le
+# This Dockerfile supports amd64,arm64,ppc64le
 # Note: QEMU emulated ppc64le build might take ~6 hours
 
 # Use conda to resolve dependencies cross-platform
 FROM continuumio/miniconda3:4.11.0 as builder
+ARG TARGETPLATFORM
 
 # install libpng to system for cross-architecture support
 # https://github.com/ANTsX/ANTs/issues/1069#issuecomment-681131938
@@ -22,16 +23,18 @@ RUN apt-get update && \
 # apt install fails because libssl1.0.0 is not available for newer Debian
 # Download verification stuff from https://cmake.org/install/
 ARG CMAKE_VERSION=3.23.1
-RUN curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt && \
-    curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x86_64; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; elif [ "$TARGETPLATFORM" = "linux/ppc64le" ]; then ARCHITECTURE=x86_64; else ARCHITECTURE=x86_64; fi && \
+    curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt && \
+    curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh && \
     sha256sum -c --ignore-missing cmake-${CMAKE_VERSION}-SHA-256.txt && \
     curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt.asc && \
     gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys C6C265324BBEBDC350B513D02D2CEF1034921684 && \
     gpg --verify cmake-${CMAKE_VERSION}-SHA-256.txt.asc cmake-${CMAKE_VERSION}-SHA-256.txt
 
-RUN mkdir /opt/cmake && \
-    chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh && \
-    ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/opt/cmake
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x86_64; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then ARCHITECTURE=arm; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=aarch64; elif [ "$TARGETPLATFORM" = "linux/ppc64le" ]; then ARCHITECTURE=x86_64; else ARCHITECTURE=x86_64; fi && \
+    mkdir /opt/cmake && \
+    chmod +x cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh && \
+    ./cmake-${CMAKE_VERSION}-linux-${ARCHITECTURE}.sh --skip-license --prefix=/opt/cmake
 
 ENV PATH=/opt/cmake/bin:${PATH}
 

--- a/tutorials/InstallingANTsPy.md
+++ b/tutorials/InstallingANTsPy.md
@@ -110,7 +110,7 @@ For cross-platform builds with buildx, the following is suggested by @jennydaman
 
 ```
 # enable QEMU emulation for targeted foreign architectures
-docker run --rm --privileged aptman/qus -s -- -p ppc64le
+docker run --rm --privileged aptman/qus -s -- -p ppc64le aarch64
 # enable advanced buildx features such as multi-platform support
 docker buildx create --name moc_builder --use
 
@@ -119,7 +119,7 @@ docker buildx create --name moc_builder --use
 # targeting the platforms amd64 and ppc64le
 # updating the base image first
 # and finally pushing the result to a container registry
-docker buildx build --pull --build-arg j=6 -t dockeruser/antspy:latest --platform linux/amd64,linux/ppc64le --push .
+docker buildx build --pull --build-arg j=6 -t dockeruser/antspy:latest --platform linux/amd64,linux/ppc64le,linux/arm64 --push .
 
 # optional clean-up
 docker buildx rm


### PR DESCRIPTION
I've made a few changes to the `Dockerfile` to be able to build `linux/arm64` images with [native compatibility](https://docs.docker.com/desktop/mac/apple-silicon/) for M1 Apple Silicon.

Notably, `cmake` sourced from [github repo](https://github.com/Kitware/CMake/releases) would always fetch the `x86_64` binary even if the the defined `--platform` was not `linux/amd64`. Besides, the github repo didn't have native binaries for `ppc64le`. Therefore, the `ppc64le` build would fail even if a conditional `$architecture` variable was defined.

It made sense to replace the github binaries with the ones from the [anaconda repo](https://anaconda.org/anaconda/cmake) (`conda install -c anaconda cmake`) supporting multiple architectures, even if slightly outdated (`3.22.1` at the time of writing). `conda-forge` has the latest one (`3.23.1`) but I didn't have the time to create the builds. I can test and push this in the coming weeks with a pinned version variable.

I can confirm the containers work on M1 without any issues for a [web application](https://hub.docker.com/r/noelmni/pynoel-gui-app/tags) I developed, with `antspyx` and `antspynet` as dependencies.

`antspyx` builds available here: https://hub.docker.com/r/noelmni/antspy


|Build System|`amd64`|`arm64`*|`ppc64le`*|
|--- |--- |--- |---|
|Intel Xeon Silver 4116 w/ Ubuntu 18.04.6 LTS x86_64 (`j=42`)|1.3 hours|~12.5 hours| ~9 hours|
*`QEMU emulated`