### PR TITLE
Hotfix 380

### DIFF
--- a/ants/registration/apply_transforms.py
+++ b/ants/registration/apply_transforms.py
@@ -1,6 +1,9 @@
 __all__ = ["apply_transforms", "apply_transforms_to_points"]
 
 import os
+from warnings import warn
+
+import numpy as np
 
 from .. import core, utils
 from ..core import ants_image as iio
@@ -131,6 +134,18 @@ def apply_transforms(
             m = moving
             if (moving.dimension == 4) and (fixed.dimension == 3) and (imagetype == 0):
                 raise Exception("Set imagetype 3 to transform time series images.")
+
+            # check that the user actually submitted a label image
+            # transforming intensity images with label interpolators can take a very long time
+            if interpolator in ["nearestNeighbor", "multiLabel", "genericLabel"]:
+                # if more than 5% of voxels are unique, moving probably isn't a label image
+                if len(np.unique(moving)) > np.prod(moving.shape) * 0.05:
+                    warn(
+                        (
+                            "moving has a large number of unique values. "
+                            "Did you accidentally pass an intensity image or mean to use a continuous interpolator?"
+                        )
+                    )
 
             wmo = warpedmovout
             mytx = []


### PR DESCRIPTION
Adds warning when raised when a label interpolator is used with an image with a suspiciously high cardinality.

A potential problem: runtime

Counting unique voxels takes about 10s on a large image (1000 x 500 x 250), due to using the 'quick' and dirty method of `len(np.unique(moving))`. The warning only needs a rough estimate of cardinality though.  Runtime could be significantly improved using something like hyperloglog or calculating cardinality for a random sample of voxels. 