### PR TITLE
BUG: kelly_kapowski its parameter needs brackets

### DIFF
--- a/ants/segmentation/kelly_kapowski.py
+++ b/ants/segmentation/kelly_kapowski.py
@@ -63,7 +63,7 @@ def kelly_kapowski(s, g, w, its=45, r=0.025, m=1.5, **kwargs):
                 's': s,
                 'g': g,
                 'w': w,
-                'c': its,
+                'c': "[{}]".format(its),
                 'r': r,
                 'm': m,
                 'o': outimg}


### PR DESCRIPTION
When run as documented, specifying `its` as an integer does not work. KellyKapowski requires brackets, ie "-c [45]".