### PR TITLE
native `arm64` docker images + wheel builds for `linux_aarch64` and `macosx_arm64` using Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.11.4
+    - python -m pip install cibuildwheel==2.12.0
   run_cibuildwheel_script:
     - cibuildwheel
   wheels_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,9 @@ macos_arm64_wheel_task:
     - CIBW_BUILD: cp310-macosx_arm64
     - CIBW_BUILD: cp311-macosx_arm64
     CIBW_ARCHS_MACOS: "arm64"
-    CIBW_BEFORE_ALL_MACOS: python -m pip install cmake ninja
+    CIBW_BEFORE_ALL_MACOS: |
+      python -m pip install --upgrade pip setuptools
+      python -m pip install cmake ninja
     CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,8 +134,8 @@ macos_arm64_wheel_task:
     matrix:
     # - CIBW_BUILD: cp38-macosx_arm64
     - CIBW_BUILD: cp39-macosx_arm64
-    # - CIBW_BUILD: cp310-macosx_arm64
-    # - CIBW_BUILD: cp311-macosx_arm64
+    - CIBW_BUILD: cp310-macosx_arm64
+    - CIBW_BUILD: cp311-macosx_arm64
     CIBW_ARCHS_MACOS: "arm64"
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 linux_aarch64_task:
   name: build_linux_aarch64_wheels
   timeout_in: 120m
-  only_if: ${CIRRUS_PR} != ''
+  # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   env:
     matrix:
       - CIBW_BUILD: "cp36-manylinux*"
@@ -103,7 +103,7 @@ linux_aarch64_task:
 
 macos_arm64_task:
   name: build_macos_arm64_wheels
-  only_if: ${CIRRUS_PR} != ''
+  # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
@@ -131,7 +131,7 @@ macos_arm64_task:
 docker_builder:
   name: build_linux_x86_64_image
   timeout_in: 120m
-  only_if: ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
+  # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
   required_pr_labels: 
     - opened
     - reopened
@@ -150,7 +150,7 @@ docker_builder:
 docker_builder:
   name: build_linux_aarch64_image
   timeout_in: 120m
-  only_if: ${CIRRUS_PR} != ''
+  # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
   required_pr_labels: 
     - opened
     - reopened
@@ -171,7 +171,7 @@ docker_builder:
 docker_builder:
   name: build_unified_multiarch_image
   timeout_in: 120m
-  only_if: ${CIRRUS_PR} != ''
+  # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
   depends_on:
     - build_linux_x86_64_image
     - build_linux_aarch64_image

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,8 +142,7 @@ macos_arm64_wheel_task:
       conda install cmake ninja libpng
     CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
-      conda env update -n base -f environment.yml &&
-      python -m pip install --no-deps --find-links=wheelhouse/
+      python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     PATH: $HOME/mambaforge/bin/:$PATH
     CONDA_HOME: $HOME/mambaforge

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,7 +124,7 @@ docker_builder:
     ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}-latest
     curl -O http://${CIRRUS_HTTP_CACHE_HOST}/tmp.env
     export $(cat tmp.env)
-    if [[ "$ANTSPY_VERSION" != "" ]]; then
+    if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
       ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
     fi
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,7 +64,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 linux_aarch64_task:
   name: build_linux_aarch64_wheels
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_BRANCH} =~ 'pull/.*'
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   env:
     matrix:
       - CIBW_BUILD: "cp36-manylinux*"
@@ -103,7 +103,7 @@ linux_aarch64_task:
 
 macos_arm64_task:
   name: build_macos_arm64_wheels
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_BRANCH} =~ 'pull/.*'
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
@@ -131,7 +131,7 @@ macos_arm64_task:
 docker_builder:
   name: build_linux_x86_64_image
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_BRANCH} =~ 'pull/.*'
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
   required_pr_labels: 
     - opened
     - reopened
@@ -141,7 +141,7 @@ docker_builder:
     - docker --version
   build_script: docker build --tag ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_x86_64} .
   login_script: |
-    if [[ "${CIRRUS_PR}" == "" ]]; then
+    if [[ "${CIRRUS_PR}" == '' ]]; then
       docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
     fi
   push_script: docker push ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_x86_64}
@@ -150,7 +150,7 @@ docker_builder:
 docker_builder:
   name: build_linux_aarch64_image
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_BRANCH} =~ 'pull/.*'
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
   required_pr_labels: 
     - opened
     - reopened
@@ -162,7 +162,7 @@ docker_builder:
     - docker --version
   build_script: docker build --tag ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_AARCH64} .
   login_script: |
-    if [[ "${CIRRUS_PR}" == "" ]]; then
+    if [[ "${CIRRUS_PR}" == '' ]]; then
       docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
     fi
   push_script: docker push ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_AARCH64}
@@ -171,7 +171,7 @@ docker_builder:
 docker_builder:
   name: build_unified_multiarch_image
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} !=~ 'pull/.*'
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
   depends_on:
     - build_linux_x86_64_image
     - build_linux_aarch64_image

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,11 @@
+env:
+  CIBW_BUILD_VERBOSITY: 3
+  DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+  DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+  TAG_x86_64: ci-x86_64-tmp
+  TAG_AARCH64: ci-aarch64-tmp
+
+
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_script:
     - python -m pip install cibuildwheel==2.12.0
@@ -23,7 +31,6 @@ linux_aarch64_task:
     CIBW_BEFORE_ALL_LINUX: |
       yum install -y gcc-c++ libpng-devel libpng
       python -m pip install cmake ninja
-    CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
@@ -43,7 +50,7 @@ linux_aarch64_task:
    - ENVFILE=tmp.env
    - echo "ANTSPY_VERSION=$(python setup.py --version)" >> ${ENVFILE}
    # https://cirrus-ci.org/guide/writing-tasks/#http-cache
-   - curl -s -X POST --data-binary @${ENVFILE} http://$CIRRUS_HTTP_CACHE_HOST/${ENVFILE}
+   - curl -s -X POST --data-binary @${ENVFILE} http://${CIRRUS_HTTP_CACHE_HOST}/${ENVFILE}
   <<: *BUILD_AND_STORE_WHEELS
 
 
@@ -61,12 +68,11 @@ macos_arm64_task:
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade
       conda install cmake ninja libpng
-    CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     CIBW_TEST_SKIP: cp38-macosx_*:arm64
-    PATH: $HOME/mambaforge/bin/:$PATH
+    PATH: $HOME/mambaforge/bin/:${PATH}
     CONDA_HOME: $HOME/mambaforge
   conda_script:
     - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
@@ -77,15 +83,10 @@ macos_arm64_task:
 docker_builder:
   name: build_linux_x86_64_image
   timeout_in: 120m
-  env:
-    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG_x86_64: ci-x86_64-tmp
-    CIBW_BUILD_VERBOSITY: 3
   setup_script:
     - docker --version
   build_script: docker build --tag noelmni/antspy:${TAG_x86_64} .
-  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  login_script: docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
   push_script: docker push noelmni/antspy:${TAG_x86_64}
 
 
@@ -94,14 +95,10 @@ docker_builder:
   timeout_in: 120m
   env:
     CIRRUS_ARCH: arm64
-    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG_AARCH64: ci-aarch64-tmp
-    CIBW_BUILD_VERBOSITY: 3
   setup_script:
     - docker --version
   build_script: docker build --tag noelmni/antspy:${TAG_AARCH64} .
-  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  login_script: docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
   push_script: docker push noelmni/antspy:${TAG_AARCH64}
 
 
@@ -113,23 +110,19 @@ docker_builder:
     - build_linux_aarch64_image
   env:
     DOCKER_CLI_EXPERIMENTAL: enabled
-    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
     BRANCH_TAG: ${CIRRUS_BRANCH}
     SHORT_SHA_TAG: ${CIRRUS_CHANGE_IN_REPO:0:7}
     TAG_MULTIARCH: ${BRANCH_TAG}-{SHORT_SHA_TAG}
-    TAG_AARCH64: ci-aarch64-tmp
-    TAG_x86_64: ci-x86_64-tmp
   script: |
     docker info
-    docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
+    docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
     docker manifest create noelmni/antspy:${TAG_MULTIARCH} --amend noelmni/antspy:${TAG_x86_64} noelmni/antspy:${TAG_AARCH64}
     docker manifest push noelmni/antspy:${TAG_MULTIARCH}
     curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
     chmod 755 regctl
     ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}
     ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}-latest
-    curl -O http://$CIRRUS_HTTP_CACHE_HOST/tmp.env
+    curl -O http://${CIRRUS_HTTP_CACHE_HOST}/tmp.env
     export $(cat tmp.env)
     if [[ "$ANTSPY_VERSION" != "" ]]; then
       ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
@@ -151,7 +144,6 @@ docker_builder:
 #     CIBW_BEFORE_ALL_LINUX: |
 #       yum install -y gcc-c++ libpng-devel libpng
 #       python -m pip install cmake ninja
-#     CIBW_BUILD_VERBOSITY: 3
 #     CIBW_BEFORE_TEST: >
 #       python -m pip install --find-links=wheelhouse/ -r requirements.txt
 #     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,7 @@
 env:
   CIBW_BUILD_VERBOSITY: 3
+  DOCKERHUB_ORG: antsx
+  DOCKERHUB_REPO: antspy
   DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
   DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
   GITHUB_TOKEN: ENCRYPTED[!PLACEHOLDER_FOR_GITHUB_TOKEN!]
@@ -132,9 +134,9 @@ docker_builder:
     - ready_for_review
   setup_script:
     - docker --version
-  build_script: docker build --tag noelmni/antspy:${TAG_x86_64} .
+  build_script: docker build --tag ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_x86_64} .
   login_script: docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
-  push_script: docker push noelmni/antspy:${TAG_x86_64}
+  push_script: docker push ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_x86_64}
 
 
 docker_builder:
@@ -150,9 +152,9 @@ docker_builder:
     CIRRUS_ARCH: arm64
   setup_script:
     - docker --version
-  build_script: docker build --tag noelmni/antspy:${TAG_AARCH64} .
+  build_script: docker build --tag ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_AARCH64} .
   login_script: docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
-  push_script: docker push noelmni/antspy:${TAG_AARCH64}
+  push_script: docker push ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_AARCH64}
 
 
 docker_builder:
@@ -177,14 +179,14 @@ docker_builder:
     # combine docker images into one
     docker info
     docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
-    docker manifest create noelmni/antspy:${TAG_MULTIARCH} --amend noelmni/antspy:${TAG_x86_64} noelmni/antspy:${TAG_AARCH64}
-    docker manifest push noelmni/antspy:${TAG_MULTIARCH}
+    docker manifest create ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_MULTIARCH} --amend ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_x86_64} ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_AARCH64}
+    docker manifest push ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_MULTIARCH}
 
     # install regctl to streamline docker tagging
     curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
     chmod 755 regctl
-    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${CIRRUS_BRANCH}
-    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${TAG_LATEST}
+    ./regctl image copy ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_MULTIARCH} ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${CIRRUS_BRANCH}
+    ./regctl image copy ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_MULTIARCH} ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_LATEST}
 
     # retrieve and export environment variable(s)
     curl -O http://${CIRRUS_HTTP_CACHE_HOST}/tmp.env
@@ -192,7 +194,7 @@ docker_builder:
 
     # tag the image with version information only on release
     if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
-      ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
+      ./regctl image copy ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_MULTIARCH} ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:v${ANTSPY_VERSION}
     fi
 
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,10 @@ docker_builder:
   setup_script:
     - docker --version
   build_script: docker build --tag ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_x86_64} .
-  login_script: docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+  login_script: |
+    if [[ "${CIRRUS_PR}" == "" ]]; then
+      docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+    fi
   push_script: docker push ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_x86_64}
 
 
@@ -153,7 +156,10 @@ docker_builder:
   setup_script:
     - docker --version
   build_script: docker build --tag ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_AARCH64} .
-  login_script: docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+  login_script: |
+    if [[ "${CIRRUS_PR}" == "" ]]; then
+      docker login --username ${DOCKER_USERNAME} --password ${DOCKER_PASSWORD}
+    fi
   push_script: docker push ${DOCKERHUB_ORG}/${DOCKERHUB_REPO}:${TAG_AARCH64}
 
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,7 @@ macos_arm64_wheel_task:
     - CIBW_BUILD: cp39-macosx_arm64
     - CIBW_BUILD: cp310-macosx_arm64
     # - CIBW_BUILD: cp311-macosx_arm64
-    CIBW_ARCHS_MACOS: "arm64"
+    CIBW_ARCHS_MACOS: x86_64 arm64
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade
       conda install cmake ninja libpng

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,10 +62,10 @@ macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
     matrix:
-    - CIBW_BUILD: cp38-macosx_arm64
-    - CIBW_BUILD: cp39-macosx_arm64
-    - CIBW_BUILD: cp310-macosx_arm64
-    - CIBW_BUILD: cp311-macosx_arm64
+      - CIBW_BUILD: cp38-macosx_arm64
+      - CIBW_BUILD: cp39-macosx_arm64
+      - CIBW_BUILD: cp310-macosx_arm64
+      - CIBW_BUILD: cp311-macosx_arm64
     CIBW_ARCHS_MACOS: arm64
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade
@@ -151,7 +151,7 @@ docker_builder:
     curl -O http://${CIRRUS_HTTP_CACHE_HOST}/tmp.env
     export $(cat tmp.env)
 
-    # tag the image with version information on release
+    # tag the image with version information only on release
     if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
       ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
     fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,7 +96,7 @@ docker_builder:
     - docker --version
   build_script: docker build --tag noelmni/antspy:${TAG_AARCH64} .
   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-  push_script: docker push noelmni/antspy:$TAG-${TAG_AARCH64}
+  push_script: docker push noelmni/antspy:${TAG_AARCH64}
 
 
 docker_builder:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     - pipx run build --sdist # make a source distribution
   upload_releases_script: |
     #!/usr/bin/env bash
+
     if [[ "${CIRRUS_RELEASE}" == "" ]]; then
       CIRRUS_RELEASE=$(curl -sL https://api.github.com/repos/${CIRRUS_REPO_FULL_NAME}/releases/tags/${CIRRUS_TAG} | jq -r '.id')
       if [[ "${CIRRUS_RELEASE}" == "null" ]]; then
@@ -29,10 +30,12 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
         exit 0
       fi
     fi
+
     if [[ "${GITHUB_TOKEN}" == "" ]]; then
       echo "Please provide GitHub access token via GITHUB_TOKEN environment variable!"
       exit 1
     fi
+
      # deploy wheels to GitHub
     for WHEELS in wheelhouse/*
     do
@@ -46,8 +49,10 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
         --header "Content-Type: application/octet-stream" \
         ${URL_TO_UPLOAD}
     done
+
     # deploy source distribution to PyPI using 'twine'
     pipx run twine upload -r pypi dist/*
+
     # deploy wheels to PyPI
     pipx run twine upload -r pypi wheelhouse/*
   sdist_artifacts:
@@ -173,9 +178,12 @@ docker_builder:
   env:
     DOCKER_CLI_EXPERIMENTAL: enabled
   script: |
+    #!/usr/bin/env bash
+
     # define docker tags
     SHORT_SHA_TAG=$(git rev-parse --short ${CIRRUS_CHANGE_IN_REPO})
     TAG_MULTIARCH=${CIRRUS_BRANCH}-${SHORT_SHA_TAG}
+    
     if [[ "${CIRRUS_BRANCH}" == "master" ]]; then
       TAG_LATEST=latest
     else

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -112,7 +112,7 @@ docker_builder:
     DOCKER_CLI_EXPERIMENTAL: enabled
     BRANCH_TAG: ${CIRRUS_BRANCH}
     SHORT_SHA_TAG: ${CIRRUS_CHANGE_IN_REPO:0:7}
-    TAG_MULTIARCH: ${BRANCH_TAG}-{SHORT_SHA_TAG}
+    TAG_MULTIARCH: ${BRANCH_TAG}-${SHORT_SHA_TAG}
   script: |
     docker info
     docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,7 +142,8 @@ macos_arm64_wheel_task:
       conda install cmake ninja libpng
     CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
-      python -m pip install --find-links=wheelhouse/ -r requirements.txt
+      conda env update -n base -f environment.yml &&
+      python -m pip install --no-deps --find-links=wheelhouse/
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     PATH: $HOME/mambaforge/bin/:$PATH
     CONDA_HOME: $HOME/mambaforge

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,8 +78,9 @@ linux_aarch64_task:
     CIBW_BEFORE_ALL_LINUX: |
       yum install -y gcc-c++ libpng-devel libpng
       python -m pip install cmake ninja
-    CIBW_BEFORE_TEST: >
-      python -m pip install --find-links=wheelhouse/ -r requirements.txt
+    CIBW_BEFORE_TEST: |
+      python -m pip install --find-links=wheelhouse/ antspyx
+      python -m pip install -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
   compute_engine_instance:
@@ -117,7 +118,8 @@ macos_arm64_task:
       python -m ensurepip --upgrade
       conda install cmake ninja libpng
     CIBW_BEFORE_TEST: >
-      python -m pip install --find-links=wheelhouse/ -r requirements.txt
+      python -m pip install --find-links=wheelhouse/ antspyx
+      python -m pip install -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     CIBW_TEST_SKIP: cp38-macosx_*:arm64
     PATH: $HOME/mambaforge/bin/:${PATH}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,6 +39,9 @@ linux_aarch64_task:
    - export DEBIAN_FRONTEND=noninteractive
    - apt-get update
    - apt-get install -y python3-dev python-is-python3
+   get_version_script:
+   - echo "$(python setup.py --version)" >> ${ANTSPY_VERSION}
+   - echo ${ANTSPY_VERSION}
   <<: *BUILD_AND_STORE_WHEELS
 
 
@@ -120,10 +123,13 @@ docker_builder:
     docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
     docker manifest create noelmni/antspy:${TAG_MULTIARCH} --amend noelmni/antspy:${TAG_x86_64} noelmni/antspy:${TAG_AARCH64}
     docker manifest push noelmni/antspy:${TAG_MULTIARCH}
-    docker pull noelmni/antspy:${TAG_MULTIARCH}
-    docker tag noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}
-    docker tag noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:latest
-    docker push noelmni/antspy
+    curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
+    chmod 755 regctl
+    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}
+    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}-latest
+    if [[ "$ANTSPY_VERSION" != "" ]]; then
+      ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
+    fi
 
 
 # linux_x86_64_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -91,6 +91,7 @@ docker_builder:
 
 docker_builder:
   name: build_aarch64
+  timeout_in: 120m
   env:
     CIRRUS_ARCH: arm64
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,8 +103,8 @@ docker_builder:
   name: build_unified_multiarch_image
   timeout_in: 120m
   depends_on:
-    - build_x86_64
-    - build_aarch64
+    - build_linux_x86_64_image
+    - build_linux_aarch64_image
   env:
     DOCKER_CLI_EXPERIMENTAL: enabled
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,23 +127,26 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 
 macos_arm64_wheel_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode
+    matrix:
+    - image: ghcr.io/cirruslabs/macos-ventura-xcode
+    - image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
     matrix:
-    - CIBW_BUILD: cp38-macosx_arm64
+    # - CIBW_BUILD: cp38-macosx_arm64
     - CIBW_BUILD: cp39-macosx_arm64
-    - CIBW_BUILD: cp310-macosx_arm64
-    - CIBW_BUILD: cp311-macosx_arm64
+    # - CIBW_BUILD: cp310-macosx_arm64
+    # - CIBW_BUILD: cp311-macosx_arm64
     CIBW_ARCHS_MACOS: "arm64"
     CIBW_BEFORE_ALL_MACOS: |
       python -m pip install --upgrade pip setuptools
       python -m pip install cmake ninja
+      brew install libpng
     CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
   python_script:
-    - brew install python@3.10 libpng
+    - brew install python@3.10
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   <<: *BUILD_AND_STORE_WHEELS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -145,8 +145,9 @@ macos_arm64_wheel_task:
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
-    PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
-  python_script:
-    - brew install python@3.10
-    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
+    PATH: $HOME/mambaforge/bin/:$PATH
+    CONDA_HOME: $HOME/mambaforge
+  conda_script:
+    - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
+    - bash ~/mambaforge.sh -b -p ~/mambaforge
   <<: *BUILD_AND_STORE_WHEELS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 env:
   CIBW_BUILD_VERBOSITY: 3
-  DOCKERHUB_ORG: antsx
+  DOCKERHUB_ORG: noelmni
   DOCKERHUB_REPO: antspy
   DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
   DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
@@ -64,7 +64,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 linux_aarch64_task:
   name: build_linux_aarch64_wheels
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
+  only_if: ${CIRRUS_PR} != ''
   env:
     matrix:
       - CIBW_BUILD: "cp36-manylinux*"
@@ -103,7 +103,7 @@ linux_aarch64_task:
 
 macos_arm64_task:
   name: build_macos_arm64_wheels
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
+  only_if: ${CIRRUS_PR} != ''
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
@@ -131,7 +131,7 @@ macos_arm64_task:
 docker_builder:
   name: build_linux_x86_64_image
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
+  only_if: ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
   required_pr_labels: 
     - opened
     - reopened
@@ -150,7 +150,7 @@ docker_builder:
 docker_builder:
   name: build_linux_aarch64_image
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
+  only_if: ${CIRRUS_PR} != ''
   required_pr_labels: 
     - opened
     - reopened
@@ -171,7 +171,7 @@ docker_builder:
 docker_builder:
   name: build_unified_multiarch_image
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_PR} != ''
+  only_if: ${CIRRUS_PR} != ''
   depends_on:
     - build_linux_x86_64_image
     - build_linux_aarch64_image

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -150,7 +150,7 @@ docker_builder:
 docker_builder:
   name: build_linux_aarch64_image
   timeout_in: 120m
-  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} == 'v*' || ${CIRRUS_BRANCH} =~ 'pull/.*'
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_BRANCH} =~ 'pull/.*'
   required_pr_labels: 
     - opened
     - reopened
@@ -183,7 +183,7 @@ docker_builder:
     # define docker tags
     SHORT_SHA_TAG=$(git rev-parse --short ${CIRRUS_CHANGE_IN_REPO})
     TAG_MULTIARCH=${CIRRUS_BRANCH}-${SHORT_SHA_TAG}
-    
+
     if [[ "${CIRRUS_BRANCH}" == "master" ]]; then
       TAG_LATEST=latest
     else

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,32 +74,51 @@ linux_aarch64_task:
   <<: *BUILD_AND_STORE_WHEELS
 
 
-# docker_builder:
-#   name: Build x86 docker images
-#   timeout_in: 120m
-#   env:
-#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-#     TAG: cirrus-ci
-#     CIBW_BUILD_VERBOSITY: 3
-#   setup_script:
-#     - docker --version
-#   build_script: docker build --tag noelmni/antspy:$TAG .
-#   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-#   push_script: docker push noelmni/antspy:$TAG
+docker_builder:
+  name: build_x86_64
+  timeout_in: 120m
+  env:
+    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+    TAG: cirrus-ci
+    CIBW_BUILD_VERBOSITY: 3
+  setup_script:
+    - docker --version
+  build_script: docker build --tag noelmni/antspy:$TAG .
+  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  push_script: docker push noelmni/antspy:$TAG
 
 
-# docker_builder:
-#   name: Build aarch64 docker images
-#   timeout_in: 120m
-#   env:
-#     CIRRUS_ARCH: arm64
-#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-#     TAG: cirrus-ci
-#     CIBW_BUILD_VERBOSITY: 3
-#   setup_script:
-#     - docker --version
-#   build_script: docker build --tag noelmni/antspy:$TAG-$CIRRUS_ARCH .
-#   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-#   push_script: docker push noelmni/antspy:$TAG-$CIRRUS_ARCH
+docker_builder:
+  name: build_aarch64
+  env:
+    CIRRUS_ARCH: arm64
+    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+    TAG: cirrus-ci
+    CIBW_BUILD_VERBOSITY: 3
+  setup_script:
+    - docker --version
+  build_script: docker build --tag noelmni/antspy:$TAG-$CIRRUS_ARCH .
+  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  push_script: docker push noelmni/antspy:$TAG-$CIRRUS_ARCH
+
+
+docker_builder:
+  name: multiarch_build
+  timeout_in: 120m
+  depends_on:
+    - build_x86_64
+    - build_aarch64
+  env:
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+    TAG_MULTIARCH: multiarch
+    TAG_AARCH64: cirrus-ci-arm64
+    TAG_X86_64: cirrus-ci
+  script: |
+    docker info
+    docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
+    docker manifest create noelmni/antspy:$TAG_MULTIARCH --amend noelmni/antspy:$TAG_X86_64 noelmni/antspy:$TAG_AARCH64
+    docker manifest push noelmni/antspy:$TAG_MULTIARCH

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 
 
 linux_aarch64_task:
-  name: Build Linux aarch64 wheels
+  name: build_linux_aarch64_wheels
   timeout_in: 120m
   env:
     matrix:
@@ -42,6 +42,7 @@ linux_aarch64_task:
 
 
 macos_arm64_wheel_task:
+  name: build_macos_arm64_wheels
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
@@ -68,7 +69,7 @@ macos_arm64_wheel_task:
 
 
 docker_builder:
-  name: build_x86_64
+  name: build_linux_x86_64_image
   timeout_in: 120m
   env:
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
@@ -83,7 +84,7 @@ docker_builder:
 
 
 docker_builder:
-  name: build_aarch64
+  name: build_linux_aarch64_image
   timeout_in: 120m
   env:
     CIRRUS_ARCH: arm64
@@ -99,7 +100,7 @@ docker_builder:
 
 
 docker_builder:
-  name: unified_build
+  name: build_unified_multiarch_image
   timeout_in: 120m
   depends_on:
     - build_x86_64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,15 +3,21 @@ env:
   DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
   DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
   GITHUB_TOKEN: ENCRYPTED[!PLACEHOLDER_FOR_GITHUB_TOKEN!]
+  TWINE_USERNAME: ENCRYPTED[!PLACEHOLDER_FOR_TWINE_USERNAME!] # username for pypi
+  TWINE_PASSWORD: ENCRYPTED[!PLACEHOLDER_FOR_TWINE_PASSWORD!] # password for pypi
   TAG_x86_64: ci-x86_64-tmp
   TAG_AARCH64: ci-aarch64-tmp
 
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
-  install_cibuildwheel_script:
-    - python -m pip install cibuildwheel==2.12.0
+  install_cibuildwheel_pipx_script:
+    - python -m pip install cibuildwheel==2.12.0 pipx
+    - python -m pipx ensurepath
   run_cibuildwheel_script:
     - cibuildwheel
+  make_sdist_script:
+    - rm -rf dist # clear out your 'dist' folder 
+    - pipx run build --sdist # make a source distribution
   upload_releases_script: |
     #!/usr/bin/env bash
     if [[ "${CIRRUS_RELEASE}" == "" ]]; then
@@ -25,6 +31,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
       echo "Please provide GitHub access token via GITHUB_TOKEN environment variable!"
       exit 1
     fi
+     # deploy wheels to GitHub
     for WHEELS in wheelhouse/*
     do
       echo "Uploading ${WHEELS}..."
@@ -37,6 +44,12 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
         --header "Content-Type: application/octet-stream" \
         ${URL_TO_UPLOAD}
     done
+    # deploy source distribution to PyPI using 'twine'
+    pipx run twine upload -r pypi dist/*
+    # deploy wheels to PyPI
+    pipx run twine upload -r pypi wheelhouse/*
+  sdist_artifacts:
+    path: "dist/*.tar.gz"
   wheels_artifacts:
     path: "wheelhouse/*"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -139,8 +139,7 @@ macos_arm64_wheel_task:
     CIBW_ARCHS_MACOS: "arm64"
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade
-      python -m pip install cmake ninja
-      brew install libpng
+      conda install cmake ninja libpng
     CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,6 +18,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 linux_aarch64_task:
   name: build_linux_aarch64_wheels
   timeout_in: 120m
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_BRANCH} =~ 'pull/.*'
   env:
     matrix:
       - CIBW_BUILD: "cp36-manylinux*"
@@ -56,6 +57,7 @@ linux_aarch64_task:
 
 macos_arm64_task:
   name: build_macos_arm64_wheels
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_BRANCH} =~ 'pull/.*'
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
@@ -83,6 +85,12 @@ macos_arm64_task:
 docker_builder:
   name: build_linux_x86_64_image
   timeout_in: 120m
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} =~ 'v*' || ${CIRRUS_BRANCH} =~ 'pull/.*'
+  required_pr_labels: 
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
   setup_script:
     - docker --version
   build_script: docker build --tag noelmni/antspy:${TAG_x86_64} .
@@ -93,6 +101,12 @@ docker_builder:
 docker_builder:
   name: build_linux_aarch64_image
   timeout_in: 120m
+  only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_TAG} == 'v*' || ${CIRRUS_BRANCH} =~ 'pull/.*'
+  required_pr_labels: 
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
   env:
     CIRRUS_ARCH: arm64
   setup_script:
@@ -105,6 +119,7 @@ docker_builder:
 docker_builder:
   name: build_unified_multiarch_image
   timeout_in: 120m
+  only_if: ${CIRRUS_BRANCH} !=~ 'pull/.*'
   depends_on:
     - build_linux_x86_64_image
     - build_linux_aarch64_image
@@ -144,6 +159,7 @@ docker_builder:
 
 # linux_x86_64_task:
 #   name: Build Linux x86_64 wheels
+#   only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_BRANCH} =~ 'pull/.*'
 #   timeout_in: 120m
 #   env:
 #     matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,7 +58,7 @@ linux_aarch64_task:
     CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
-    CIBW_TEST_COMMAND: ./tests/run_tests.sh
+    CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
   compute_engine_instance:
     image_project: cirrus-images

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,13 +73,13 @@ docker_builder:
   env:
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG: cirrus-ci
+    TAG_x86_64: ci-x86_64
     CIBW_BUILD_VERBOSITY: 3
   setup_script:
     - docker --version
-  build_script: docker build --tag noelmni/antspy:$TAG .
+  build_script: docker build --tag noelmni/antspy:${TAG_x86_64} .
   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-  push_script: docker push noelmni/antspy:$TAG
+  push_script: docker push noelmni/antspy:${TAG_x86_64}
 
 
 docker_builder:
@@ -89,17 +89,17 @@ docker_builder:
     CIRRUS_ARCH: arm64
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG: cirrus-ci
+    TAG_AARCH64: ci-aarch64
     CIBW_BUILD_VERBOSITY: 3
   setup_script:
     - docker --version
-  build_script: docker build --tag noelmni/antspy:$TAG-$CIRRUS_ARCH .
+  build_script: docker build --tag noelmni/antspy:${TAG_AARCH64} .
   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-  push_script: docker push noelmni/antspy:$TAG-$CIRRUS_ARCH
+  push_script: docker push noelmni/antspy:$TAG-${TAG_AARCH64}
 
 
 docker_builder:
-  name: multiarch_build
+  name: unified_build
   timeout_in: 120m
   depends_on:
     - build_x86_64
@@ -108,14 +108,14 @@ docker_builder:
     DOCKER_CLI_EXPERIMENTAL: enabled
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG_MULTIARCH: multiarch
-    TAG_AARCH64: cirrus-ci-arm64
-    TAG_X86_64: cirrus-ci
+    TAG_MULTIARCH: ci-latest
+    TAG_AARCH64: ci-aarch64
+    TAG_x86_64: ci-x86_64
   script: |
     docker info
     docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
-    docker manifest create noelmni/antspy:$TAG_MULTIARCH --amend noelmni/antspy:$TAG_X86_64 noelmni/antspy:$TAG_AARCH64
-    docker manifest push noelmni/antspy:$TAG_MULTIARCH
+    docker manifest create noelmni/antspy:${TAG_MULTIARCH} --amend noelmni/antspy:${TAG_x86_64} noelmni/antspy:${TAG_AARCH64}
+    docker manifest push noelmni/antspy:${TAG_MULTIARCH}
 
 
 # linux_x86_64_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -110,7 +110,9 @@ docker_builder:
     DOCKER_CLI_EXPERIMENTAL: enabled
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG_MULTIARCH: ci-latest
+    BRANCH_TAG: ${CIRRUS_BRANCH}
+    SHORT_SHA_TAG: ${CIRRUS_CHANGE_IN_REPO:0:7}
+    TAG_MULTIARCH: ${BRANCH_TAG}-{SHORT_SHA_TAG}
     TAG_AARCH64: ci-aarch64-tmp
     TAG_x86_64: ci-x86_64-tmp
   script: |
@@ -118,6 +120,10 @@ docker_builder:
     docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
     docker manifest create noelmni/antspy:${TAG_MULTIARCH} --amend noelmni/antspy:${TAG_x86_64} noelmni/antspy:${TAG_AARCH64}
     docker manifest push noelmni/antspy:${TAG_MULTIARCH}
+    docker pull noelmni/antspy:${TAG_MULTIARCH}
+    docker tag noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}
+    docker tag noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:latest
+    docker push noelmni/antspy
 
 
 # linux_x86_64_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -110,10 +110,16 @@ docker_builder:
     - build_linux_aarch64_image
   env:
     DOCKER_CLI_EXPERIMENTAL: enabled
-    BRANCH_TAG: ${CIRRUS_BRANCH}
-    SHORT_SHA_TAG: ${CIRRUS_CHANGE_IN_REPO:0:7}
-    TAG_MULTIARCH: ${BRANCH_TAG}-${SHORT_SHA_TAG}
   script: |
+    # define docker tags
+    SHORT_SHA_TAG=$(git rev-parse --short ${CIRRUS_CHANGE_IN_REPO})
+    TAG_MULTIARCH=${CIRRUS_BRANCH}-${SHORT_SHA_TAG}
+    if [[ "${CIRRUS_BRANCH}" == "master" ]]; then
+      TAG_LATEST=latest
+    else
+      TAG_LATEST=${CIRRUS_BRANCH}-latest
+    fi
+
     # combine docker images into one
     docker info
     docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
@@ -123,8 +129,8 @@ docker_builder:
     # install regctl to streamline docker tagging
     curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
     chmod 755 regctl
-    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}
-    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}-latest
+    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${CIRRUS_BRANCH}
+    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${TAG_LATEST}
 
     # retrieve and export environment variable(s)
     curl -O http://${CIRRUS_HTTP_CACHE_HOST}/tmp.env

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,6 +17,7 @@ linux_aarch64_task:
       - CIBW_BUILD: "cp38-manylinux*"
       - CIBW_BUILD: "cp39-manylinux*"
       - CIBW_BUILD: "cp310-manylinux*"
+      - CIBW_BUILD: "cp311-manylinux*"
     CIBW_ARCHS_LINUX: "auto"
     CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
     CIBW_BEFORE_ALL_LINUX: |
@@ -50,7 +51,7 @@ macos_arm64_wheel_task:
     - CIBW_BUILD: cp38-macosx_arm64
     - CIBW_BUILD: cp39-macosx_arm64
     - CIBW_BUILD: cp310-macosx_arm64
-    # - CIBW_BUILD: cp311-macosx_arm64
+    - CIBW_BUILD: cp311-macosx_arm64
     CIBW_ARCHS_MACOS: arm64
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,7 +127,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 
 macos_arm64_wheel_task:
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode
+    image: ghcr.io/cirruslabs/macos-ventura-xcode
   env:
     matrix:
     - CIBW_BUILD: cp38-macosx_arm64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,16 +114,23 @@ docker_builder:
     SHORT_SHA_TAG: ${CIRRUS_CHANGE_IN_REPO:0:7}
     TAG_MULTIARCH: ${BRANCH_TAG}-${SHORT_SHA_TAG}
   script: |
+    # combine docker images into one
     docker info
     docker login --username=${DOCKER_USERNAME} --password=${DOCKER_PASSWORD}
     docker manifest create noelmni/antspy:${TAG_MULTIARCH} --amend noelmni/antspy:${TAG_x86_64} noelmni/antspy:${TAG_AARCH64}
     docker manifest push noelmni/antspy:${TAG_MULTIARCH}
+
+    # install regctl to streamline docker tagging
     curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 > regctl
     chmod 755 regctl
     ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}
     ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}-latest
+
+    # retrieve and export environment variable(s)
     curl -O http://${CIRRUS_HTTP_CACHE_HOST}/tmp.env
     export $(cat tmp.env)
+
+    # tag the image with version information on release
     if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
       ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
     fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -131,9 +131,9 @@ docker_builder:
     export $(cat tmp.env)
 
     # tag the image with version information on release
-    if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
-      ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
-    fi
+    # if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
+    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
+    # fi
 
 
 # linux_x86_64_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,119 +7,142 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     path: "wheelhouse/*"
 
 
-linux_x86_64_task:
-  name: Build Linux x86_64 wheels
-  timeout_in: 120m
+# linux_x86_64_task:
+#   name: Build Linux x86_64 wheels
+#   timeout_in: 120m
+#   env:
+#     matrix:
+#       # - CIBW_BUILD: "cp36-manylinux*"
+#       # - CIBW_BUILD: "cp37-manylinux*"
+#       # - CIBW_BUILD: "cp38-manylinux*"
+#       - CIBW_BUILD: "cp39-manylinux*"
+#       - CIBW_BUILD: "cp310-manylinux*"
+#     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+#     CIBW_ARCHS_LINUX: "auto64"
+#     CIBW_BEFORE_ALL_LINUX: |
+#       yum install -y gcc-c++ libpng-devel libpng
+#       python -m pip install cmake ninja
+#     CIBW_BUILD_VERBOSITY: 3
+#     CIBW_BEFORE_TEST: >
+#       python -m pip install --find-links=wheelhouse/ -r requirements.txt
+#     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
+#     # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
+#   compute_engine_instance:
+#     image_project: cirrus-images
+#     image: family/docker-builder
+#     platform: linux
+#     cpu: 2
+#     memory: 2G
+#   install_pre_requirements_script:
+#    - export DEBIAN_FRONTEND=noninteractive
+#    - apt-get update
+#    - apt-get install -y python3-dev python-is-python3
+#   <<: *BUILD_AND_STORE_WHEELS
+
+
+# linux_aarch64_task:
+#   name: Build Linux aarch64 wheels
+#   timeout_in: 120m
+#   env:
+#     matrix:
+#       # - CIBW_BUILD: "cp36-manylinux*"
+#       # - CIBW_BUILD: "cp37-manylinux*"
+#       # - CIBW_BUILD: "cp38-manylinux*"
+#       - CIBW_BUILD: "cp39-manylinux*"
+#       - CIBW_BUILD: "cp310-manylinux*"
+#     CIBW_ARCHS_LINUX: "auto"
+#     CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+#     CIBW_BEFORE_ALL_LINUX: |
+#       yum install -y gcc-c++ libpng-devel libpng
+#       python -m pip install cmake ninja
+#     CIBW_BUILD_VERBOSITY: 3
+#     CIBW_BEFORE_TEST: >
+#       python -m pip install --find-links=wheelhouse/ -r requirements.txt
+#     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
+#     # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
+#   compute_engine_instance:
+#     image_project: cirrus-images
+#     image: family/docker-builder-arm64
+#     architecture: arm64
+#     platform: linux
+#     cpu: 2
+#     memory: 2G
+#   install_pre_requirements_script:
+#    - export DEBIAN_FRONTEND=noninteractive
+#    - apt-get update
+#    - apt-get install -y python3-dev python-is-python3
+#   <<: *BUILD_AND_STORE_WHEELS
+
+
+# docker_builder:
+#   name: build_x86_64
+#   timeout_in: 120m
+#   env:
+#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+#     TAG: cirrus-ci
+#     CIBW_BUILD_VERBOSITY: 3
+#   setup_script:
+#     - docker --version
+#   build_script: docker build --tag noelmni/antspy:$TAG .
+#   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+#   push_script: docker push noelmni/antspy:$TAG
+
+
+# docker_builder:
+#   name: build_aarch64
+#   timeout_in: 120m
+#   env:
+#     CIRRUS_ARCH: arm64
+#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+#     TAG: cirrus-ci
+#     CIBW_BUILD_VERBOSITY: 3
+#   setup_script:
+#     - docker --version
+#   build_script: docker build --tag noelmni/antspy:$TAG-$CIRRUS_ARCH .
+#   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+#   push_script: docker push noelmni/antspy:$TAG-$CIRRUS_ARCH
+
+
+# docker_builder:
+#   name: multiarch_build
+#   timeout_in: 120m
+#   depends_on:
+#     - build_x86_64
+#     - build_aarch64
+#   env:
+#     DOCKER_CLI_EXPERIMENTAL: enabled
+#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+#     TAG_MULTIARCH: multiarch
+#     TAG_AARCH64: cirrus-ci-arm64
+#     TAG_X86_64: cirrus-ci
+#   script: |
+#     docker info
+#     docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
+#     docker manifest create noelmni/antspy:$TAG_MULTIARCH --amend noelmni/antspy:$TAG_X86_64 noelmni/antspy:$TAG_AARCH64
+#     docker manifest push noelmni/antspy:$TAG_MULTIARCH
+
+
+macos_arm64_wheel_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
     matrix:
-      # - CIBW_BUILD: "cp36-manylinux*"
-      # - CIBW_BUILD: "cp37-manylinux*"
-      # - CIBW_BUILD: "cp38-manylinux*"
-      - CIBW_BUILD: "cp39-manylinux*"
-      - CIBW_BUILD: "cp310-manylinux*"
-    CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-    CIBW_ARCHS_LINUX: "auto64"
-    CIBW_BEFORE_ALL_LINUX: |
-      yum install -y gcc-c++ libpng-devel libpng
-      python -m pip install cmake ninja
+    - CIBW_BUILD: cp38-macosx_arm64
+    - CIBW_BUILD: cp39-macosx_arm64
+    - CIBW_BUILD: cp310-macosx_arm64
+    - CIBW_BUILD: cp311-macosx_arm64
+    CIBW_ARCHS_MACOS: "arm64"
+    CIBW_BEFORE_ALL_MACOS: python -m pip install cmake ninja
     CIBW_BUILD_VERBOSITY: 3
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
-    # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder
-    platform: linux
-    cpu: 2
-    memory: 2G
-  install_pre_requirements_script:
-   - export DEBIAN_FRONTEND=noninteractive
-   - apt-get update
-   - apt-get install -y python3-dev python-is-python3
+    PATH: $HOME/mambaforge/bin/:$PATH
+    CONDA_HOME: $HOME/mambaforge
+  conda_script:
+    - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
+    - bash ~/mambaforge.sh -b -p ~/mambaforge
   <<: *BUILD_AND_STORE_WHEELS
-
-
-linux_aarch64_task:
-  name: Build Linux aarch64 wheels
-  timeout_in: 120m
-  env:
-    matrix:
-      # - CIBW_BUILD: "cp36-manylinux*"
-      # - CIBW_BUILD: "cp37-manylinux*"
-      # - CIBW_BUILD: "cp38-manylinux*"
-      - CIBW_BUILD: "cp39-manylinux*"
-      - CIBW_BUILD: "cp310-manylinux*"
-    CIBW_ARCHS_LINUX: "auto"
-    CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-    CIBW_BEFORE_ALL_LINUX: |
-      yum install -y gcc-c++ libpng-devel libpng
-      python -m pip install cmake ninja
-    CIBW_BUILD_VERBOSITY: 3
-    CIBW_BEFORE_TEST: >
-      python -m pip install --find-links=wheelhouse/ -r requirements.txt
-    CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
-    # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
-  compute_engine_instance:
-    image_project: cirrus-images
-    image: family/docker-builder-arm64
-    architecture: arm64
-    platform: linux
-    cpu: 2
-    memory: 2G
-  install_pre_requirements_script:
-   - export DEBIAN_FRONTEND=noninteractive
-   - apt-get update
-   - apt-get install -y python3-dev python-is-python3
-  <<: *BUILD_AND_STORE_WHEELS
-
-
-docker_builder:
-  name: build_x86_64
-  timeout_in: 120m
-  env:
-    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG: cirrus-ci
-    CIBW_BUILD_VERBOSITY: 3
-  setup_script:
-    - docker --version
-  build_script: docker build --tag noelmni/antspy:$TAG .
-  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-  push_script: docker push noelmni/antspy:$TAG
-
-
-docker_builder:
-  name: build_aarch64
-  timeout_in: 120m
-  env:
-    CIRRUS_ARCH: arm64
-    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG: cirrus-ci
-    CIBW_BUILD_VERBOSITY: 3
-  setup_script:
-    - docker --version
-  build_script: docker build --tag noelmni/antspy:$TAG-$CIRRUS_ARCH .
-  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-  push_script: docker push noelmni/antspy:$TAG-$CIRRUS_ARCH
-
-
-docker_builder:
-  name: multiarch_build
-  timeout_in: 120m
-  depends_on:
-    - build_x86_64
-    - build_aarch64
-  env:
-    DOCKER_CLI_EXPERIMENTAL: enabled
-    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG_MULTIARCH: multiarch
-    TAG_AARCH64: cirrus-ci-arm64
-    TAG_X86_64: cirrus-ci
-  script: |
-    docker info
-    docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
-    docker manifest create noelmni/antspy:$TAG_MULTIARCH --amend noelmni/antspy:$TAG_X86_64 noelmni/antspy:$TAG_AARCH64
-    docker manifest push noelmni/antspy:$TAG_MULTIARCH

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,7 @@ env:
   CIBW_BUILD_VERBOSITY: 3
   DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
   DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+  GITHUB_TOKEN: ENCRYPTED[!PLACEHOLDER_FOR_GITHUB_TOKEN!]
   TAG_x86_64: ci-x86_64-tmp
   TAG_AARCH64: ci-aarch64-tmp
 
@@ -11,6 +12,31 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     - python -m pip install cibuildwheel==2.12.0
   run_cibuildwheel_script:
     - cibuildwheel
+  upload_releases_script: |
+    #!/usr/bin/env bash
+    if [[ "${CIRRUS_RELEASE}" == "" ]]; then
+      CIRRUS_RELEASE=$(curl -sL https://api.github.com/repos/${CIRRUS_REPO_FULL_NAME}/releases/tags/${CIRRUS_TAG} | jq -r '.id')
+      if [[ "${CIRRUS_RELEASE}" == "null" ]]; then
+        echo "Failed to find a release associated with this tag!"
+        exit 0
+      fi
+    fi
+    if [[ "${GITHUB_TOKEN}" == "" ]]; then
+      echo "Please provide GitHub access token via GITHUB_TOKEN environment variable!"
+      exit 1
+    fi
+    for WHEELS in wheelhouse/*
+    do
+      echo "Uploading ${WHEELS}..."
+      NAME=$(basename "${WHEELS}")
+      URL_TO_UPLOAD="https://uploads.github.com/repos/${CIRRUS_REPO_FULL_NAME}/releases/${CIRRUS_RELEASE}/assets?name=${NAME}"
+      echo "Uploading to ${URL_TO_UPLOAD}"
+      curl -X POST \
+        --data-binary @${WHEELS} \
+        --header "Authorization: token ${GITHUB_TOKEN}" \
+        --header "Content-Type: application/octet-stream" \
+        ${URL_TO_UPLOAD}
+    done
   wheels_artifacts:
     path: "wheelhouse/*"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,10 +132,10 @@ macos_arm64_wheel_task:
     - image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
     matrix:
-    # - CIBW_BUILD: cp38-macosx_arm64
+    - CIBW_BUILD: cp38-macosx_arm64
     - CIBW_BUILD: cp39-macosx_arm64
     - CIBW_BUILD: cp310-macosx_arm64
-    - CIBW_BUILD: cp311-macosx_arm64
+    # - CIBW_BUILD: cp311-macosx_arm64
     CIBW_ARCHS_MACOS: "arm64"
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -138,7 +138,7 @@ macos_arm64_wheel_task:
     # - CIBW_BUILD: cp311-macosx_arm64
     CIBW_ARCHS_MACOS: "arm64"
     CIBW_BEFORE_ALL_MACOS: |
-      python -m pip install --upgrade pip setuptools
+      python -m ensurepip --upgrade
       python -m pip install cmake ninja
       brew install libpng
     CIBW_BUILD_VERBOSITY: 3

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,7 @@ macos_arm64_wheel_task:
     - CIBW_BUILD: cp39-macosx_arm64
     - CIBW_BUILD: cp310-macosx_arm64
     # - CIBW_BUILD: cp311-macosx_arm64
-    CIBW_ARCHS_MACOS: x86_64 arm64
+    CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade
       conda install cmake ninja libpng

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ env:
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_pipx_script:
-    - python -m pip install cibuildwheel==2.12.0 pipx
+    - python -m pip install cibuildwheel==2.12.0 pipx jq
     - python -m pipx ensurepath
   run_cibuildwheel_script:
     - cibuildwheel

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,9 +127,7 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
 
 macos_arm64_wheel_task:
   macos_instance:
-    matrix:
-    - image: ghcr.io/cirruslabs/macos-ventura-xcode
-    - image: ghcr.io/cirruslabs/macos-monterey-xcode
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
   env:
     matrix:
     - CIBW_BUILD: cp38-macosx_arm64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -137,9 +137,9 @@ docker_builder:
     export $(cat tmp.env)
 
     # tag the image with version information on release
-    # if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
-    ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
-    # fi
+    if [ "${ANTSPY_VERSION}" != "" ] && [ "${CIRRUS_RELEASE}" != "" ]; then
+      ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
+    fi
 
 
 # linux_x86_64_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,7 +74,7 @@ docker_builder:
   env:
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG_x86_64: ci-x86_64
+    TAG_x86_64: ci-x86_64-tmp
     CIBW_BUILD_VERBOSITY: 3
   setup_script:
     - docker --version
@@ -90,7 +90,7 @@ docker_builder:
     CIRRUS_ARCH: arm64
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-    TAG_AARCH64: ci-aarch64
+    TAG_AARCH64: ci-aarch64-tmp
     CIBW_BUILD_VERBOSITY: 3
   setup_script:
     - docker --version
@@ -110,8 +110,8 @@ docker_builder:
     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
     TAG_MULTIARCH: ci-latest
-    TAG_AARCH64: ci-aarch64
-    TAG_x86_64: ci-x86_64
+    TAG_AARCH64: ci-aarch64-tmp
+    TAG_x86_64: ci-x86_64-tmp
   script: |
     docker info
     docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,7 +39,7 @@ linux_aarch64_task:
    - export DEBIAN_FRONTEND=noninteractive
    - apt-get update
    - apt-get install -y python3-dev python-is-python3
-   get_version_script:
+  get_version_script:
    - echo "$(python setup.py --version)" >> ${ANTSPY_VERSION}
    - echo ${ANTSPY_VERSION}
   <<: *BUILD_AND_STORE_WHEELS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -144,6 +144,7 @@ macos_arm64_wheel_task:
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
+    CIBW_TEST_SKIP: cp38-macosx_*:arm64
     PATH: $HOME/mambaforge/bin/:$PATH
     CONDA_HOME: $HOME/mambaforge
   conda_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ macos_arm64_wheel_task:
     - CIBW_BUILD: cp39-macosx_arm64
     - CIBW_BUILD: cp310-macosx_arm64
     # - CIBW_BUILD: cp311-macosx_arm64
-    CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+    CIBW_ARCHS_MACOS: arm64
     CIBW_BEFORE_ALL_MACOS: |
       python -m ensurepip --upgrade
       conda install cmake ninja libpng

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,122 +7,38 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
     path: "wheelhouse/*"
 
 
-# linux_x86_64_task:
-#   name: Build Linux x86_64 wheels
-#   timeout_in: 120m
-#   env:
-#     matrix:
-#       # - CIBW_BUILD: "cp36-manylinux*"
-#       # - CIBW_BUILD: "cp37-manylinux*"
-#       # - CIBW_BUILD: "cp38-manylinux*"
-#       - CIBW_BUILD: "cp39-manylinux*"
-#       - CIBW_BUILD: "cp310-manylinux*"
-#     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-#     CIBW_ARCHS_LINUX: "auto64"
-#     CIBW_BEFORE_ALL_LINUX: |
-#       yum install -y gcc-c++ libpng-devel libpng
-#       python -m pip install cmake ninja
-#     CIBW_BUILD_VERBOSITY: 3
-#     CIBW_BEFORE_TEST: >
-#       python -m pip install --find-links=wheelhouse/ -r requirements.txt
-#     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
-#     # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
-#   compute_engine_instance:
-#     image_project: cirrus-images
-#     image: family/docker-builder
-#     platform: linux
-#     cpu: 2
-#     memory: 2G
-#   install_pre_requirements_script:
-#    - export DEBIAN_FRONTEND=noninteractive
-#    - apt-get update
-#    - apt-get install -y python3-dev python-is-python3
-#   <<: *BUILD_AND_STORE_WHEELS
-
-
-# linux_aarch64_task:
-#   name: Build Linux aarch64 wheels
-#   timeout_in: 120m
-#   env:
-#     matrix:
-#       # - CIBW_BUILD: "cp36-manylinux*"
-#       # - CIBW_BUILD: "cp37-manylinux*"
-#       # - CIBW_BUILD: "cp38-manylinux*"
-#       - CIBW_BUILD: "cp39-manylinux*"
-#       - CIBW_BUILD: "cp310-manylinux*"
-#     CIBW_ARCHS_LINUX: "auto"
-#     CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
-#     CIBW_BEFORE_ALL_LINUX: |
-#       yum install -y gcc-c++ libpng-devel libpng
-#       python -m pip install cmake ninja
-#     CIBW_BUILD_VERBOSITY: 3
-#     CIBW_BEFORE_TEST: >
-#       python -m pip install --find-links=wheelhouse/ -r requirements.txt
-#     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
-#     # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
-#   compute_engine_instance:
-#     image_project: cirrus-images
-#     image: family/docker-builder-arm64
-#     architecture: arm64
-#     platform: linux
-#     cpu: 2
-#     memory: 2G
-#   install_pre_requirements_script:
-#    - export DEBIAN_FRONTEND=noninteractive
-#    - apt-get update
-#    - apt-get install -y python3-dev python-is-python3
-#   <<: *BUILD_AND_STORE_WHEELS
-
-
-# docker_builder:
-#   name: build_x86_64
-#   timeout_in: 120m
-#   env:
-#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-#     TAG: cirrus-ci
-#     CIBW_BUILD_VERBOSITY: 3
-#   setup_script:
-#     - docker --version
-#   build_script: docker build --tag noelmni/antspy:$TAG .
-#   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-#   push_script: docker push noelmni/antspy:$TAG
-
-
-# docker_builder:
-#   name: build_aarch64
-#   timeout_in: 120m
-#   env:
-#     CIRRUS_ARCH: arm64
-#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-#     TAG: cirrus-ci
-#     CIBW_BUILD_VERBOSITY: 3
-#   setup_script:
-#     - docker --version
-#   build_script: docker build --tag noelmni/antspy:$TAG-$CIRRUS_ARCH .
-#   login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
-#   push_script: docker push noelmni/antspy:$TAG-$CIRRUS_ARCH
-
-
-# docker_builder:
-#   name: multiarch_build
-#   timeout_in: 120m
-#   depends_on:
-#     - build_x86_64
-#     - build_aarch64
-#   env:
-#     DOCKER_CLI_EXPERIMENTAL: enabled
-#     DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-#     DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-#     TAG_MULTIARCH: multiarch
-#     TAG_AARCH64: cirrus-ci-arm64
-#     TAG_X86_64: cirrus-ci
-#   script: |
-#     docker info
-#     docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
-#     docker manifest create noelmni/antspy:$TAG_MULTIARCH --amend noelmni/antspy:$TAG_X86_64 noelmni/antspy:$TAG_AARCH64
-#     docker manifest push noelmni/antspy:$TAG_MULTIARCH
+linux_aarch64_task:
+  name: Build Linux aarch64 wheels
+  timeout_in: 120m
+  env:
+    matrix:
+      - CIBW_BUILD: "cp36-manylinux*"
+      - CIBW_BUILD: "cp37-manylinux*"
+      - CIBW_BUILD: "cp38-manylinux*"
+      - CIBW_BUILD: "cp39-manylinux*"
+      - CIBW_BUILD: "cp310-manylinux*"
+    CIBW_ARCHS_LINUX: "auto"
+    CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+    CIBW_BEFORE_ALL_LINUX: |
+      yum install -y gcc-c++ libpng-devel libpng
+      python -m pip install cmake ninja
+    CIBW_BUILD_VERBOSITY: 3
+    CIBW_BEFORE_TEST: >
+      python -m pip install --find-links=wheelhouse/ -r requirements.txt
+    CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
+    # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 2
+    memory: 2G
+  install_pre_requirements_script:
+   - export DEBIAN_FRONTEND=noninteractive
+   - apt-get update
+   - apt-get install -y python3-dev python-is-python3
+  <<: *BUILD_AND_STORE_WHEELS
 
 
 macos_arm64_wheel_task:
@@ -149,3 +65,87 @@ macos_arm64_wheel_task:
     - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
     - bash ~/mambaforge.sh -b -p ~/mambaforge
   <<: *BUILD_AND_STORE_WHEELS
+
+
+docker_builder:
+  name: build_x86_64
+  timeout_in: 120m
+  env:
+    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+    TAG: cirrus-ci
+    CIBW_BUILD_VERBOSITY: 3
+  setup_script:
+    - docker --version
+  build_script: docker build --tag noelmni/antspy:$TAG .
+  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  push_script: docker push noelmni/antspy:$TAG
+
+
+docker_builder:
+  name: build_aarch64
+  timeout_in: 120m
+  env:
+    CIRRUS_ARCH: arm64
+    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+    TAG: cirrus-ci
+    CIBW_BUILD_VERBOSITY: 3
+  setup_script:
+    - docker --version
+  build_script: docker build --tag noelmni/antspy:$TAG-$CIRRUS_ARCH .
+  login_script: docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  push_script: docker push noelmni/antspy:$TAG-$CIRRUS_ARCH
+
+
+docker_builder:
+  name: multiarch_build
+  timeout_in: 120m
+  depends_on:
+    - build_x86_64
+    - build_aarch64
+  env:
+    DOCKER_CLI_EXPERIMENTAL: enabled
+    DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
+    DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
+    TAG_MULTIARCH: multiarch
+    TAG_AARCH64: cirrus-ci-arm64
+    TAG_X86_64: cirrus-ci
+  script: |
+    docker info
+    docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD 
+    docker manifest create noelmni/antspy:$TAG_MULTIARCH --amend noelmni/antspy:$TAG_X86_64 noelmni/antspy:$TAG_AARCH64
+    docker manifest push noelmni/antspy:$TAG_MULTIARCH
+
+
+# linux_x86_64_task:
+#   name: Build Linux x86_64 wheels
+#   timeout_in: 120m
+#   env:
+#     matrix:
+#       - CIBW_BUILD: "cp36-manylinux*"
+#       - CIBW_BUILD: "cp37-manylinux*"
+#       - CIBW_BUILD: "cp38-manylinux*"
+#       - CIBW_BUILD: "cp39-manylinux*"
+#       - CIBW_BUILD: "cp310-manylinux*"
+#     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+#     CIBW_ARCHS_LINUX: "auto64"
+#     CIBW_BEFORE_ALL_LINUX: |
+#       yum install -y gcc-c++ libpng-devel libpng
+#       python -m pip install cmake ninja
+#     CIBW_BUILD_VERBOSITY: 3
+#     CIBW_BEFORE_TEST: >
+#       python -m pip install --find-links=wheelhouse/ -r requirements.txt
+#     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
+#     # CIBW_ENVIRONMENT: PIP_GLOBAL_OPTION="build_ext -j4"
+#   compute_engine_instance:
+#     image_project: cirrus-images
+#     image: family/docker-builder
+#     platform: linux
+#     cpu: 2
+#     memory: 2G
+#   install_pre_requirements_script:
+#    - export DEBIAN_FRONTEND=noninteractive
+#    - apt-get update
+#    - apt-get install -y python3-dev python-is-python3
+#   <<: *BUILD_AND_STORE_WHEELS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ linux_aarch64_task:
   <<: *BUILD_AND_STORE_WHEELS
 
 
-macos_arm64_wheel_task:
+macos_arm64_task:
   name: build_macos_arm64_wheels
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -144,6 +144,6 @@ macos_arm64_wheel_task:
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
     PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
   python_script:
-    - brew install python@3.10
+    - brew install python@3.10 libpng
     - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   <<: *BUILD_AND_STORE_WHEELS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,9 +142,8 @@ macos_arm64_wheel_task:
     CIBW_BEFORE_TEST: >
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
-    PATH: $HOME/mambaforge/bin/:$PATH
-    CONDA_HOME: $HOME/mambaforge
-  conda_script:
-    - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
-    - bash ~/mambaforge.sh -b -p ~/mambaforge
+    PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
+  python_script:
+    - brew install python@3.10
+    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
   <<: *BUILD_AND_STORE_WHEELS

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,8 +40,10 @@ linux_aarch64_task:
    - apt-get update
    - apt-get install -y python3-dev python-is-python3
   get_version_script:
-   - echo "$(python setup.py --version)" >> ${ANTSPY_VERSION}
-   - echo ${ANTSPY_VERSION}
+   - ENVFILE=tmp.env
+   - echo "ANTSPY_VERSION=$(python setup.py --version)" >> ${ENVFILE}
+   # https://cirrus-ci.org/guide/writing-tasks/#http-cache
+   - curl -s -X POST --data-binary @${ENVFILE} http://$CIRRUS_HTTP_CACHE_HOST/${ENVFILE}
   <<: *BUILD_AND_STORE_WHEELS
 
 
@@ -127,6 +129,8 @@ docker_builder:
     chmod 755 regctl
     ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}
     ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:${BRANCH_TAG}-latest
+    curl -O http://$CIRRUS_HTTP_CACHE_HOST/tmp.env
+    export $(cat tmp.env)
     if [[ "$ANTSPY_VERSION" != "" ]]; then
       ./regctl image copy noelmni/antspy:${TAG_MULTIARCH} noelmni/antspy:v${ANTSPY_VERSION}
     fi

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.cirrus.yml
 .circleci/
 .github/
 appveyor/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -96,7 +96,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.1
+        run: python -m pip install cibuildwheel==2.12.0
 
       - name: Build wheels
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ COPY environment.yml .
 RUN conda env update -n base
 COPY . .
 
-# parallelize make jobs
-ARG MAKEFLAGS="-j$(nproc)"
+# number of parallel make jobs
+ARG j=2
 RUN pip --no-cache-dir -v install .
 
 # run tests

--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -595,25 +595,25 @@ if HAS_PY3:
     # Set partial class methods for any functions which take an ANTsImage as the first argument
     for k, v in utils.__dict__.items():
         if callable(v):
-            args = inspect.getargspec(getattr(utils,k)).args
+            args = inspect.getfullargspec(getattr(utils,k)).args
             if (len(args) > 0) and (args[0] in {'img','image'}):
                 setattr(ANTsImage, k, partialmethod(v))
 
     for k, v in registration.__dict__.items():
         if callable(v):
-            args = inspect.getargspec(getattr(registration,k)).args
+            args = inspect.getfullargspec(getattr(registration,k)).args
             if (len(args) > 0) and (args[0] in {'img','image'}):
                 setattr(ANTsImage, k, partialmethod(v))
 
     for k, v in segmentation.__dict__.items():
         if callable(v):
-            args = inspect.getargspec(getattr(segmentation,k)).args
+            args = inspect.getfullargspec(getattr(segmentation,k)).args
             if (len(args) > 0) and (args[0] in {'img','image'}):
                 setattr(ANTsImage, k, partialmethod(v))
 
     for k, v in viz.__dict__.items():
         if callable(v):
-            args = inspect.getargspec(getattr(viz,k)).args
+            args = inspect.getfullargspec(getattr(viz,k)).args
             if (len(args) > 0) and (args[0] in {'img','image'}):
                 setattr(ANTsImage, k, partialmethod(v))
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,5 @@
 # TODO: pin dependency versions
 name: antspy
-channels:
-  - default
-  - conda-forge
 dependencies:
 - pandas
 - pyyaml
@@ -10,7 +7,8 @@ dependencies:
 - scikit-image
 - scikit-learn
 - statsmodels
-- webcolors
 - matplotlib
 - Pillow
+pip:
 - nibabel
+- webcolors

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,8 @@
 # TODO: pin dependency versions
 name: antspy
+channels:
+  - default
+  - conda-forge
 dependencies:
 - pandas
 - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,12 @@
 name: antspy
 dependencies:
 - pandas
+- pyyaml
 - numpy
-- scipy
 - scikit-image
 - scikit-learn
 - statsmodels
+- webcolors
 - matplotlib
-- pyyaml
 - Pillow
+- nibabel

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ webcolors
 matplotlib
 Pillow
 nibabel
+Cython>=0.23.4 --install-option='--no-cython-compile'; python_version < "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pandas
 pyyaml
-sklearn
 numpy
 scikit-image
 scikit-learn


### PR DESCRIPTION
All docker images and wheels are built and test (`tests/build_wheels.sh`) successfully using Cirrus CI with a few exceptions (summarized in the Table below):
- `linux_aarch64`: no `py36` and `py311` wheels . `py36` fails while building `scikit-image` since no `py36` wheels exists on PyPI, and `py311` errors out while building `antspyx` possibly due to `pybind11`
- `macosx_arm64`: `cibuildwheel` on Apple Silicon only supports `py37+`. `py311` fails to build with the error similar to the one described above. The default deployment target is `macosx_11` or higher
- `docker`: both `arm64` and `x86_64` images are built and then unified into a single docker image

|   | Linux aarch64 | macOS Apple Silicon | Docker |
|---------------|:----:|:----:|:----:|
| CPython 3.6   | ❌ | N/A | N/A  | 
| CPython 3.7   | ✅ | N/A | N/A  | 
| CPython 3.8   | ✅ | ✅  | N/A | 
| CPython 3.9   | ✅ | ✅  | N/A  | 
| CPython 3.10  | ✅ | ✅  | ✅  | 
| CPython 3.11  | ✅  | ✅   | N/A | 

GitHub Actions can successfully build `cp36` on `linux_x86_64`, so possibly something to do with `arm64`, but I haven't investigated these failures further yet.

Build artifacts and detailed logs can be found here: https://cirrus-ci.com/build/5986395915812864

UPDATE: fixed `py311` support for `arm64` and `x86_64`