### PR TITLE
COMP: Add support for python 3.11, remove 3.6 from CI build wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,9 +43,9 @@ jobs:
           - os: ubuntu-latest
             python: 310
             platform_id: manylinux_x86_64
-          # - os: ubuntu-latest
-          #  python: 311
-          #  platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_x86_64
 
           # macOS on Intel 64-bit
           - os: macos-latest
@@ -88,7 +88,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python host for cibuildwheel
         with:
           python-version: '3.9'
@@ -99,7 +99,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.3.1
+        run: python -m pip install cibuildwheel==2.12.0
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -84,7 +84,7 @@ jobs:
           #   platform_id: macosx_arm64
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -126,6 +126,6 @@ jobs:
 
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,9 +12,6 @@ jobs:
         include:
           # Windows 64-bit
           - os: windows-latest
-            python: 36
-            platform_id: win_amd64
-          - os: windows-latest
             python: 37
             platform_id: win_amd64
           - os: windows-latest
@@ -28,9 +25,6 @@ jobs:
             platform_id: win_amd64
 
           # Linux 64-bit
-          - os: ubuntu-latest
-            python: 36
-            platform_id: manylinux_x86_64
           - os: ubuntu-latest
             python: 37
             platform_id: manylinux_x86_64
@@ -48,10 +42,6 @@ jobs:
             platform_id: manylinux_x86_64
 
           # macOS on Intel 64-bit
-          - os: macos-latest
-            python: 36
-            arch: x86_64
-            platform_id: macosx_x86_64
           - os: macos-latest
             python: 37
             arch: x86_64


### PR DESCRIPTION
Testing if this will work with an update to cibuildwheel version

Also update the python setup app to avoid Github deprecation warnings