### PR TITLE
Added ANTsSerializer to replace previous `_int_antsProcessArguments` and `get_pointer_string`

### DIFF
--- a/ants/registration/affine_initializer.py
+++ b/ants/registration/affine_initializer.py
@@ -58,10 +58,11 @@ def affine_initializer(fixed_image, moving_image, search_factor=20,
                 local_search_iterations]
     if mask is not None:
         veccer.append(mask)
-
-    xxx = utils._int_antsProcessArguments(veccer)
-    libfn = utils.get_lib_fn('antsAffineInitializer')
-    retval = libfn(xxx)
+    
+    with utils.ANTsSerializer() as serializer:
+        xxx = serializer.int_antsProcessArguments(veccer)
+        libfn = utils.get_lib_fn('antsAffineInitializer')
+        retval = libfn(xxx)
 
     if retval != 0:
         warnings.warn('ERROR: Non-zero exit status!')

--- a/ants/registration/apply_transforms.py
+++ b/ants/registration/apply_transforms.py
@@ -155,26 +155,27 @@ def apply_transforms(fixed, moving, transformlist,
                         '-r', f,
                         '-n', interpolator]
                 args = args + mytx
-
-            myargs = utils._int_antsProcessArguments(args)
-
-            # NO CLUE WHAT THIS DOES OR WHY IT'S NEEDED
-            for jj in range(len(myargs)):
-                if myargs[jj] is not None:
-                    if myargs[jj] == '-':
-                        myargs2 = [None]*(len(myargs)-1)
-                        myargs2[:(jj-1)] = myargs[:(jj-1)]
-                        myargs2[jj:(len(myargs)-1)] = myargs[(jj+1):(len(myargs))]
-                        myargs = myargs2
-
-            myverb = int(verbose)
-            if verbose:
-                print(myargs)
-
-            processed_args = myargs + ['-z', str(1), '-v', str(myverb), '--float', str(1), '-e', str(imagetype), '-f', str(defaultvalue)]
-            libfn = utils.get_lib_fn('antsApplyTransforms')
-            libfn(processed_args)
-
+            
+            with utils.ANTsSerializer() as serializer:
+                myargs = serializer.int_antsProcessArguments(args)
+                
+                # NO CLUE WHAT THIS DOES OR WHY IT'S NEEDED
+                for jj in range(len(myargs)):
+                    if myargs[jj] is not None:
+                        if myargs[jj] == '-':
+                            myargs2 = [None]*(len(myargs)-1)
+                            myargs2[:(jj-1)] = myargs[:(jj-1)]
+                            myargs2[jj:(len(myargs)-1)] = myargs[(jj+1):(len(myargs))]
+                            myargs = myargs2
+                
+                myverb = int(verbose)
+                if verbose:
+                    print(myargs)
+                
+                processed_args = myargs + ['-z', str(1), '-v', str(myverb), '--float', str(1), '-e', str(imagetype), '-f', str(defaultvalue)]
+                libfn = utils.get_lib_fn('antsApplyTransforms')
+                libfn(processed_args)
+            
             if compose is None:
                 return warpedmovout.clone(inpixeltype)
             else:
@@ -187,9 +188,10 @@ def apply_transforms(fixed, moving, transformlist,
             return 1
     else:
         args = args + ['-z', 1, '--float', 1, '-e', imagetype, '-f', defaultvalue]
-        processed_args = utils._int_antsProcessArguments(args)
-        libfn = utils.get_lib_fn('antsApplyTransforms')
-        libfn(processed_args)
+        with utils.ANTsSerializer() as serializer:
+            processed_args = serializer.int_antsProcessArguments(args)
+            libfn = utils.get_lib_fn('antsApplyTransforms')
+            libfn(processed_args)
 
 
 
@@ -293,15 +295,17 @@ def apply_transforms_to_points( dim, points, transformlist,
             '-i', pointImage,
             '-o', pointsOut ]
     args = args + mytx
-    myargs = utils._int_antsProcessArguments(args)
-
-    myverb = int(verbose)
-    if verbose:
-        print(myargs)
-
-    processed_args = myargs + [ '-f', str(1), '--precision', str(0)]
-    libfn = utils.get_lib_fn('antsApplyTransformsToPoints')
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        myargs = serializer.int_antsProcessArguments(args)
+        
+        myverb = int(verbose)
+        if verbose:
+            print(myargs)
+        
+        processed_args = myargs + [ '-f', str(1), '--precision', str(0)]
+        libfn = utils.get_lib_fn('antsApplyTransformsToPoints')
+        libfn(processed_args)
     mynp = pointsOut.numpy()
     pointsOutDF = points.copy()
     pointsOutDF['x'] = mynp[:,0]

--- a/ants/registration/create_jacobian_determinant_image.py
+++ b/ants/registration/create_jacobian_determinant_image.py
@@ -54,9 +54,11 @@ def create_jacobian_determinant_image(domain_image, tx, do_log=False, geom=False
     #args = [dim, txuse, do_log]
     dimage = domain_image.clone('double')
     args2 = [dim, txuse, dimage, int(do_log), int(geom)]
-    processed_args = utils._int_antsProcessArguments(args2)
-    libfn = utils.get_lib_fn('CreateJacobianDeterminantImage')
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer.int_antsProcessArguments(args2)
+        libfn = utils.get_lib_fn('CreateJacobianDeterminantImage')
+        libfn(processed_args)
     jimage = args2[2].clone('float')
     
     return jimage

--- a/ants/registration/interface.py
+++ b/ants/registration/interface.py
@@ -215,9 +215,10 @@ def registration(
     >>> mytx = ants.registration(fixed=fi, moving=mi, type_of_transform = 'SyN' )
     """
     if isinstance(fixed, list) and (moving is None):
-        processed_args = utils._int_antsProcessArguments(fixed)
-        libfn = utils.get_lib_fn("antsRegistration")
-        reg_exit = libfn(processed_args)
+        with utils.ANTsSerializer() as serializer:
+            processed_args = serializer.int_antsProcessArguments(fixed)
+            libfn = utils.get_lib_fn("antsRegistration")
+            reg_exit = libfn(processed_args)
         if (reg_exit != 0):
             raise RuntimeError(f"Registration failed with error code {reg_exit}")
         else:
@@ -389,314 +390,42 @@ def registration(
 #    fixed = utils.iMath( fixed.clone("float"), "Normalize" )
     warpedfixout = moving.clone()
     warpedmovout = fixed.clone()
-    f = utils.get_pointer_string(fixed)
-    m = utils.get_pointer_string(moving)
-    wfo = utils.get_pointer_string(warpedfixout)
-    wmo = utils.get_pointer_string(warpedmovout)
-    if mask is not None:
-        mask_scale = mask - mask.min()
-        mask_scale = mask_scale / mask_scale.max() * 255.0
-        charmask = mask_scale.clone("unsigned char")
-        maskopt = "[%s,NA]" % (utils.get_pointer_string(charmask))
-    else:
-        maskopt = None
-    if initx is None:
-        initx = "[%s,%s,1]" % (f, m)
-    # ------------------------------------------------------------
-    if type_of_transform == "SyNBold":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Rigid[0.25]",
-            "-c",
-            "[1200x1200x100,1e-6,5]",
-            "-s",
-            "2x1x0",
-            "-f",
-            "4x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
+    with utils.ANTsSerializer() as serializer:
+        f = serializer.get_pointer_string(fixed)
+        m = serializer.get_pointer_string(moving)
+        wfo = serializer.get_pointer_string(warpedfixout)
+        wmo = serializer.get_pointer_string(warpedmovout)
+        if mask is not None:
+            mask_scale = mask - mask.min()
+            mask_scale = mask_scale / mask_scale.max() * 255.0
+            charmask = mask_scale.clone("unsigned char")
+            maskopt = "[%s,NA]" % (serializer.get_pointer_string(charmask))
         else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "SyNBoldAff":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Rigid[0.25]",
-            "-c",
-            "[1200x1200x100,1e-6,5]",
-            "-s",
-            "2x1x0",
-            "-f",
-            "4x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[0.25]",
-            "-c",
-            "[200x20,1e-6,5]",
-            "-s",
-            "1x0",
-            "-f",
-            "2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % (synits),
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "ElasticSyN":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[0.25]",
-            "-c",
-            "2100x1200x200x0",
-            "-s",
-            "3x2x1x0",
-            "-f",
-            "4x2x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % (synits),
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "SyN" or type_of_transform == "Elastic":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[0.25]",
-            "-c",
-            "2100x1200x1200x0",
-            "-s",
-            "3x2x1x0",
-            "-f",
-            "4x2x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "SyNRA":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Rigid[0.25]",
-            "-c",
-            "2100x1200x1200x0",
-            "-s",
-            "3x2x1x0",
-            "-f",
-            "4x2x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[0.25]",
-            "-c",
-            "2100x1200x1200x0",
-            "-s",
-            "3x2x1x0",
-            "-f",
-            "4x2x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "SyNOnly":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if multivariate_extras is not None:
-            metrics = []
-            for kk in range(len(multivariate_extras)):
-                metrics.append("-m")
-                metricname = multivariate_extras[kk][0]
-                metricfixed = utils.get_pointer_string(
-                    multivariate_extras[kk][1]
-                )
-                metricmov = utils.get_pointer_string(
-                    multivariate_extras[kk][2]
-                )
-                metricWeight = multivariate_extras[kk][3]
-                metricSampling = multivariate_extras[kk][4]
-                metricString = "%s[%s,%s,%s,%s]" % (
-                    metricname,
-                    metricfixed,
-                    metricmov,
-                    metricWeight,
-                    metricSampling,
-                )
-                metrics.append(metricString)
+            maskopt = None
+        if initx is None:
+            initx = "[%s,%s,1]" % (f, m)
+        # ------------------------------------------------------------
+        if type_of_transform == "SyNBold":
             args = [
                 "-d",
                 str(fixed.dimension),
                 "-r",
                 initx,
                 "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Rigid[0.25]",
+                "-c",
+                "[1200x1200x100,1e-6,5]",
+                "-s",
+                "2x1x0",
+                "-f",
+                "4x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
                 "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            ]
-            args1 = [
                 "-t",
                 mysyn,
                 "-c",
@@ -712,682 +441,956 @@ def registration(
                 "-o",
                 "[%s,%s,%s]" % (outprefix, wmo, wfo),
             ]
-            for kk in range(len(metrics)):
-                args.append(metrics[kk])
-            for kk in range(len(args1)):
-                args.append(args1[kk])
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "SyNAggro":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[0.25]",
-            "-c",
-            "2100x1200x1200x100",
-            "-s",
-            "3x2x1x0",
-            "-f",
-            "4x2x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "SyNCC":
-        syn_metric = "CC"
-        syn_sampling = 4
-        synits = "2100x1200x1200x20"
-        smoothingsigmas = "3x2x1x0"
-        shrinkfactors = "4x3x2x1"
-        mysyn = "SyN[0.15,3,0]"
-
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Rigid[1]",
-            "-c",
-            "2100x1200x1200x0",
-            "-s",
-            "3x2x1x0",
-            "-f",
-            "4x4x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[1]",
-            "-c",
-            "1200x1200x100",
-            "-s",
-            "2x1x0",
-            "-f",
-            "4x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "TRSAA":
-        itlen = len(reg_iterations)
-        itlenlow = round(itlen / 2 + 0.0001)
-        dlen = itlen - itlenlow
-        _myconvlow = [2000] * itlenlow + [0] * dlen
-        myconvlow = "x".join([str(mc) for mc in _myconvlow])
-        myconvhi = "x".join([str(r) for r in reg_iterations])
-        myconvhi = "[%s,1.e-7,10]" % myconvhi
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Translation[1]",
-            "-c",
-            myconvlow,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Rigid[1]",
-            "-c",
-            myconvlow,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Similarity[1]",
-            "-c",
-            myconvlow,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[1]",
-            "-c",
-            myconvhi,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[1]",
-            "-c",
-            myconvhi,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------s
-    elif type_of_transform == "SyNabp":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "mattes[%s,%s,1,32,regular,0.25]" % (f, m),
-            "-t",
-            "Rigid[0.1]",
-            "-c",
-            "1000x500x250x100",
-            "-s",
-            "4x2x1x0",
-            "-f",
-            "8x4x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "mattes[%s,%s,1,32,regular,0.25]" % (f, m),
-            "-t",
-            "Affine[0.1]",
-            "-c",
-            "1000x500x250x100",
-            "-s",
-            "4x2x1x0",
-            "-f",
-            "8x4x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "CC[%s,%s,0.5,4]" % (f, m),
-            "-t",
-            "SyN[0.1,3,0]",
-            "-c",
-            "50x10x0",
-            "-s",
-            "2x1x0",
-            "-f",
-            "4x2x1",
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "SyNLessAggro":
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "Affine[0.25]",
-            "-c",
-            "2100x1200x1200x100",
-            "-s",
-            "3x2x1x0",
-            "-f",
-            "4x2x2x1",
-            "-x",
-            "[NA,NA]",
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            mysyn,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform in tvTypes:
-        if grad_step is None:
-            grad_step = 1.0
-        nTimePoints = type_of_transform.split("[")[1].split("]")[0]
-        tvtx = (
-            "TimeVaryingVelocityField["
-            + str(grad_step)
-            + ","
-            + nTimePoints
-            + ","
-            + str(flow_sigma)
-            + ",0.0,"
-            + str(total_sigma)
-            + ",0]"
-        )
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            tvtx,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "0",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    elif type_of_transform == "TVMSQ":
-        if grad_step is None:
-            grad_step = 1.0
-
-        tvtx = "TimeVaryingVelocityField[%s, 4, 0.0,0.0, 0.5,0 ]" % str(
-            grad_step
-        )
-        args = [
-            "-d",
-            str(fixed.dimension),
-            # '-r', initx,
-            "-m",
-            "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
-            "-t",
-            tvtx,
-            "-c",
-            "[%s,1e-7,8]" % synits,
-            "-s",
-            smoothingsigmas,
-            "-f",
-            shrinkfactors,
-            "-u",
-            "1",
-            "-z",
-            "0",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif type_of_transform == "TVMSQC":
-        if grad_step is None:
-            grad_step = 2.0
-
-        tvtx = "TimeVaryingVelocityField[%s, 8, 1.0,0.0, 0.05,0 ]" % str(
-            grad_step
-        )
-        args = [
-            "-d",
-            str(fixed.dimension),
-            # '-r', initx,
-            "-m",
-            "demons[%s,%s,0.5,0]" % (f, m),
-            "-m",
-            "meansquares[%s,%s,1,0]" % (f, m),
-            "-t",
-            tvtx,
-            "-c",
-            "[1200x1200x100x20x0,0,5]",
-            "-s",
-            "8x6x4x2x1vox",
-            "-f",
-            "8x6x4x2x1",
-            "-u",
-            "1",
-            "-z",
-            "0",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif (
-        (type_of_transform == "Rigid")
-        or (type_of_transform == "Similarity")
-        or (type_of_transform == "Translation")
-        or (type_of_transform == "Affine")
-    ):
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-m",
-            "%s[%s,%s,1,%s,regular,%s]"
-            % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
-            "-t",
-            "%s[0.25]" % type_of_transform,
-            "-c",
-            myiterations,
-            "-s",
-            mys_aff,
-            "-f",
-            myf_aff,
-            "-u",
-            "1",
-            "-z",
-            "1",
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-    # ------------------------------------------------------------
-    elif "antsRegistrationSyN" in type_of_transform:
-
-        do_quick = False
-        if "Quick" in type_of_transform:
-            do_quick = True
-
-        subtype_of_transform = "s"
-        spline_distance = 26
-        metric_parameter = 4
-        if do_quick:
-            metric_parameter = 32
-
-        if "[" in type_of_transform and "]" in type_of_transform:
-            subtype_of_transform = type_of_transform.split("[")[1].split(
-                "]"
-            )[0]
-            if "," in subtype_of_transform:
-                subtype_of_transform_args = subtype_of_transform.split(",")
-                subtype_of_transform = subtype_of_transform_args[0]
-                if not ( subtype_of_transform == "b"
-                         or subtype_of_transform == "br"
-                         or subtype_of_transform == "bo"
-                         or subtype_of_transform == "s"
-                         or subtype_of_transform == "sr"
-                         or subtype_of_transform == "so" ):
-                    raise ValueError("Extra parameters are only valid for 's' or 'b' SyN transforms.")
-                metric_parameter = subtype_of_transform_args[1]
-                if len(subtype_of_transform_args) > 2:
-                    spline_distance = subtype_of_transform_args[2]
-
-        do_repro = False
-        if "Repro" in type_of_transform:
-            do_repro = True
-
-        if do_quick == True:
-            rigid_convergence = "[1000x500x250x0,1e-6,10]"
-        else:
-            rigid_convergence = "[1000x500x250x100,1e-6,10]"
-        rigid_shrink_factors = "8x4x2x1"
-        rigid_smoothing_sigmas = "3x2x1x0vox"
-
-        if do_quick == True:
-            affine_convergence = "[1000x500x250x0,1e-6,10]"
-        else:
-            affine_convergence = "[1000x500x250x100,1e-6,10]"
-        affine_shrink_factors = "8x4x2x1"
-        affine_smoothing_sigmas = "3x2x1x0vox"
-
-        linear_metric="MI[%s,%s,1,32,Regular,0.25]"
-        if do_repro == True:
-            linear_metric="GC[%s,%s,1,1,Regular,0.25]"
-
-        if do_quick == True:
-            syn_convergence = "[100x70x50x0,1e-6,10]"
-            metric_parameter = 32
-            syn_metric = "MI[%s,%s,1,%s]" % (f, m, metric_parameter)
-        else:
-            metric_parameter = 2
-            syn_convergence = "[100x70x50x20,1e-6,10]"
-            syn_metric = "CC[%s,%s,1,%s]" % (f, m, metric_parameter)
-        syn_shrink_factors = "8x4x2x1"
-        syn_smoothing_sigmas = "3x2x1x0vox"
-
-        if do_quick == True and do_repro == True:
-            syn_convergence = "[100x70x50x0,1e-6,10]"
-            metric_parameter = 2
-            syn_metric = "CC[%s,%s,1,%s]" % (f, m, metric_parameter)
-
-        if random_seed is None and do_repro == True:
-            random_seed = str( 1 )
-
-        tx = "Rigid"
-        if subtype_of_transform == "t":
-            tx = "Translation"
-
-        rigid_stage = [
-            "--transform",
-            tx + "[0.1]",
-            "--metric",
-            linear_metric % (f, m),
-            "--convergence",
-            rigid_convergence,
-            "--shrink-factors",
-            rigid_shrink_factors,
-            "--smoothing-sigmas",
-            rigid_smoothing_sigmas,
-        ]
-
-        affine_stage = [
-            "--transform",
-            "Affine[0.1]",
-            "--metric",
-            linear_metric % (f, m),
-            "--convergence",
-            affine_convergence,
-            "--shrink-factors",
-            affine_shrink_factors,
-            "--smoothing-sigmas",
-            affine_smoothing_sigmas,
-        ]
-
-        if subtype_of_transform == "sr" or subtype_of_transform == "br":
-            if do_quick == True:
-                syn_convergence = "[50x0,1e-6,10]"
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
             else:
-                syn_convergence = "[50x20,1e-6,10]"
-            syn_shrink_factors = "2x1"
-            syn_smoothing_sigmas = "1x0vox"
-
-        syn_stage = [
-            "--metric",
-            syn_metric,
-        ]
-
-        if multivariate_extras is not None:
-            for kk in range(len(multivariate_extras)):
-                syn_stage.append("--metric")
-                metricname = multivariate_extras[kk][0]
-                metricfixed = utils.get_pointer_string(
-                    multivariate_extras[kk][1]
-                )
-                metricmov = utils.get_pointer_string(
-                    multivariate_extras[kk][2]
-                )
-                metricWeight = multivariate_extras[kk][3]
-                metricSampling = multivariate_extras[kk][4]
-                metricString = "%s[%s,%s,%s,%s]" % (
-                    metricname,
-                    metricfixed,
-                    metricmov,
-                    metricWeight,
-                    metricSampling,
-                )
-                syn_stage.append(metricString)
-
-        syn_stage.append("--convergence")
-        syn_stage.append(syn_convergence)
-        syn_stage.append("--shrink-factors")
-        syn_stage.append(syn_shrink_factors)
-        syn_stage.append("--smoothing-sigmas")
-        syn_stage.append(syn_smoothing_sigmas)
-
-        if (
-            subtype_of_transform == "b"
-            or subtype_of_transform == "br"
-            or subtype_of_transform == "bo"
-        ):
-            syn_stage.insert(0, "BSplineSyN[0.1," + str(spline_distance) + ",0,3]")
-            syn_stage.insert(0, "--transform")
-
-        if (
-            subtype_of_transform == "s"
-            or subtype_of_transform == "sr"
-            or subtype_of_transform == "so"
-        ):
-            syn_stage.insert(0, "SyN[0.1,3,0]")
-            syn_stage.insert(0, "--transform")
-
-        args = [
-            "-d",
-            str(fixed.dimension),
-            "-r",
-            initx,
-            "-o",
-            "[%s,%s,%s]" % (outprefix, wmo, wfo),
-        ]
-
-        if subtype_of_transform == "r" or subtype_of_transform == "t":
-            args.append(rigid_stage)
-        if subtype_of_transform == "a":
-            args.append(rigid_stage)
-            args.append(affine_stage)
-        if subtype_of_transform == "b" or subtype_of_transform == "s":
-            args.append(rigid_stage)
-            args.append(affine_stage)
-            args.append(syn_stage)
-        if subtype_of_transform == "br" or subtype_of_transform == "sr":
-            args.append(rigid_stage)
-            args.append(syn_stage)
-        if subtype_of_transform == "bo" or subtype_of_transform == "so":
-            args.append(syn_stage)
-
-        if maskopt is not None:
-            args.append("-x")
-            args.append(maskopt)
-        else:
-            args.append("-x")
-            args.append("[NA,NA]")
-
-        args = list(
-            itertools.chain.from_iterable(
-                itertools.repeat(x, 1) if isinstance(x, str) else x
-                for x in args
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "SyNBoldAff":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Rigid[0.25]",
+                "-c",
+                "[1200x1200x100,1e-6,5]",
+                "-s",
+                "2x1x0",
+                "-f",
+                "4x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[0.25]",
+                "-c",
+                "[200x20,1e-6,5]",
+                "-s",
+                "1x0",
+                "-f",
+                "2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % (synits),
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "ElasticSyN":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[0.25]",
+                "-c",
+                "2100x1200x200x0",
+                "-s",
+                "3x2x1x0",
+                "-f",
+                "4x2x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % (synits),
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "SyN" or type_of_transform == "Elastic":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[0.25]",
+                "-c",
+                "2100x1200x1200x0",
+                "-s",
+                "3x2x1x0",
+                "-f",
+                "4x2x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "SyNRA":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Rigid[0.25]",
+                "-c",
+                "2100x1200x1200x0",
+                "-s",
+                "3x2x1x0",
+                "-f",
+                "4x2x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[0.25]",
+                "-c",
+                "2100x1200x1200x0",
+                "-s",
+                "3x2x1x0",
+                "-f",
+                "4x2x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "SyNOnly":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if multivariate_extras is not None:
+                metrics = []
+                for kk in range(len(multivariate_extras)):
+                    metrics.append("-m")
+                    metricname = multivariate_extras[kk][0]
+                    metricfixed = serializer.get_pointer_string(
+                        multivariate_extras[kk][1]
+                    )
+                    metricmov = serializer.get_pointer_string(
+                        multivariate_extras[kk][2]
+                    )
+                    metricWeight = multivariate_extras[kk][3]
+                    metricSampling = multivariate_extras[kk][4]
+                    metricString = "%s[%s,%s,%s,%s]" % (
+                        metricname,
+                        metricfixed,
+                        metricmov,
+                        metricWeight,
+                        metricSampling,
+                    )
+                    metrics.append(metricString)
+                args = [
+                    "-d",
+                    str(fixed.dimension),
+                    "-r",
+                    initx,
+                    "-m",
+                    "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                ]
+                args1 = [
+                    "-t",
+                    mysyn,
+                    "-c",
+                    "[%s,1e-7,8]" % synits,
+                    "-s",
+                    smoothingsigmas,
+                    "-f",
+                    shrinkfactors,
+                    "-u",
+                    "1",
+                    "-z",
+                    "1",
+                    "-o",
+                    "[%s,%s,%s]" % (outprefix, wmo, wfo),
+                ]
+                for kk in range(len(metrics)):
+                    args.append(metrics[kk])
+                for kk in range(len(args1)):
+                    args.append(args1[kk])
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "SyNAggro":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[0.25]",
+                "-c",
+                "2100x1200x1200x100",
+                "-s",
+                "3x2x1x0",
+                "-f",
+                "4x2x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "SyNCC":
+            syn_metric = "CC"
+            syn_sampling = 4
+            synits = "2100x1200x1200x20"
+            smoothingsigmas = "3x2x1x0"
+            shrinkfactors = "4x3x2x1"
+            mysyn = "SyN[0.15,3,0]"
+    
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Rigid[1]",
+                "-c",
+                "2100x1200x1200x0",
+                "-s",
+                "3x2x1x0",
+                "-f",
+                "4x4x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[1]",
+                "-c",
+                "1200x1200x100",
+                "-s",
+                "2x1x0",
+                "-f",
+                "4x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "TRSAA":
+            itlen = len(reg_iterations)
+            itlenlow = round(itlen / 2 + 0.0001)
+            dlen = itlen - itlenlow
+            _myconvlow = [2000] * itlenlow + [0] * dlen
+            myconvlow = "x".join([str(mc) for mc in _myconvlow])
+            myconvhi = "x".join([str(r) for r in reg_iterations])
+            myconvhi = "[%s,1.e-7,10]" % myconvhi
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Translation[1]",
+                "-c",
+                myconvlow,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Rigid[1]",
+                "-c",
+                myconvlow,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Similarity[1]",
+                "-c",
+                myconvlow,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[1]",
+                "-c",
+                myconvhi,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[1]",
+                "-c",
+                myconvhi,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------s
+        elif type_of_transform == "SyNabp":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "mattes[%s,%s,1,32,regular,0.25]" % (f, m),
+                "-t",
+                "Rigid[0.1]",
+                "-c",
+                "1000x500x250x100",
+                "-s",
+                "4x2x1x0",
+                "-f",
+                "8x4x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "mattes[%s,%s,1,32,regular,0.25]" % (f, m),
+                "-t",
+                "Affine[0.1]",
+                "-c",
+                "1000x500x250x100",
+                "-s",
+                "4x2x1x0",
+                "-f",
+                "8x4x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "CC[%s,%s,0.5,4]" % (f, m),
+                "-t",
+                "SyN[0.1,3,0]",
+                "-c",
+                "50x10x0",
+                "-s",
+                "2x1x0",
+                "-f",
+                "4x2x1",
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "SyNLessAggro":
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "Affine[0.25]",
+                "-c",
+                "2100x1200x1200x100",
+                "-s",
+                "3x2x1x0",
+                "-f",
+                "4x2x2x1",
+                "-x",
+                "[NA,NA]",
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                mysyn,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform in tvTypes:
+            if grad_step is None:
+                grad_step = 1.0
+            nTimePoints = type_of_transform.split("[")[1].split("]")[0]
+            tvtx = (
+                "TimeVaryingVelocityField["
+                + str(grad_step)
+                + ","
+                + nTimePoints
+                + ","
+                + str(flow_sigma)
+                + ",0.0,"
+                + str(total_sigma)
+                + ",0]"
             )
-        )
-
-    # ------------------------------------------------------------
-
-    if random_seed is not None:
-        args.append("--random-seed")
-        args.append(random_seed)
-
-    if restrict_transformation is not None:
-        args.append("-g")
-        args.append(restrict_transformationchar)
-
-    args.append("--float")
-    args.append("1")
-    args.append("--write-composite-transform")
-    args.append(write_composite_transform * 1)
-    if verbose:
-        args.append("-v")
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                tvtx,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "0",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        elif type_of_transform == "TVMSQ":
+            if grad_step is None:
+                grad_step = 1.0
+    
+            tvtx = "TimeVaryingVelocityField[%s, 4, 0.0,0.0, 0.5,0 ]" % str(
+                grad_step
+            )
+            args = [
+                "-d",
+                str(fixed.dimension),
+                # '-r', initx,
+                "-m",
+                "%s[%s,%s,1,%s]" % (syn_metric, f, m, syn_sampling),
+                "-t",
+                tvtx,
+                "-c",
+                "[%s,1e-7,8]" % synits,
+                "-s",
+                smoothingsigmas,
+                "-f",
+                shrinkfactors,
+                "-u",
+                "1",
+                "-z",
+                "0",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif type_of_transform == "TVMSQC":
+            if grad_step is None:
+                grad_step = 2.0
+    
+            tvtx = "TimeVaryingVelocityField[%s, 8, 1.0,0.0, 0.05,0 ]" % str(
+                grad_step
+            )
+            args = [
+                "-d",
+                str(fixed.dimension),
+                # '-r', initx,
+                "-m",
+                "demons[%s,%s,0.5,0]" % (f, m),
+                "-m",
+                "meansquares[%s,%s,1,0]" % (f, m),
+                "-t",
+                tvtx,
+                "-c",
+                "[1200x1200x100x20x0,0,5]",
+                "-s",
+                "8x6x4x2x1vox",
+                "-f",
+                "8x6x4x2x1",
+                "-u",
+                "1",
+                "-z",
+                "0",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif (
+            (type_of_transform == "Rigid")
+            or (type_of_transform == "Similarity")
+            or (type_of_transform == "Translation")
+            or (type_of_transform == "Affine")
+        ):
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-m",
+                "%s[%s,%s,1,%s,regular,%s]"
+                % (aff_metric, f, m, aff_sampling, aff_random_sampling_rate),
+                "-t",
+                "%s[0.25]" % type_of_transform,
+                "-c",
+                myiterations,
+                "-s",
+                mys_aff,
+                "-f",
+                myf_aff,
+                "-u",
+                "1",
+                "-z",
+                "1",
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+        # ------------------------------------------------------------
+        elif "antsRegistrationSyN" in type_of_transform:
+    
+            do_quick = False
+            if "Quick" in type_of_transform:
+                do_quick = True
+    
+            subtype_of_transform = "s"
+            spline_distance = 26
+            metric_parameter = 4
+            if do_quick:
+                metric_parameter = 32
+    
+            if "[" in type_of_transform and "]" in type_of_transform:
+                subtype_of_transform = type_of_transform.split("[")[1].split(
+                    "]"
+                )[0]
+                if "," in subtype_of_transform:
+                    subtype_of_transform_args = subtype_of_transform.split(",")
+                    subtype_of_transform = subtype_of_transform_args[0]
+                    if not ( subtype_of_transform == "b"
+                             or subtype_of_transform == "br"
+                             or subtype_of_transform == "bo"
+                             or subtype_of_transform == "s"
+                             or subtype_of_transform == "sr"
+                             or subtype_of_transform == "so" ):
+                        raise ValueError("Extra parameters are only valid for 's' or 'b' SyN transforms.")
+                    metric_parameter = subtype_of_transform_args[1]
+                    if len(subtype_of_transform_args) > 2:
+                        spline_distance = subtype_of_transform_args[2]
+    
+            do_repro = False
+            if "Repro" in type_of_transform:
+                do_repro = True
+    
+            if do_quick == True:
+                rigid_convergence = "[1000x500x250x0,1e-6,10]"
+            else:
+                rigid_convergence = "[1000x500x250x100,1e-6,10]"
+            rigid_shrink_factors = "8x4x2x1"
+            rigid_smoothing_sigmas = "3x2x1x0vox"
+    
+            if do_quick == True:
+                affine_convergence = "[1000x500x250x0,1e-6,10]"
+            else:
+                affine_convergence = "[1000x500x250x100,1e-6,10]"
+            affine_shrink_factors = "8x4x2x1"
+            affine_smoothing_sigmas = "3x2x1x0vox"
+    
+            linear_metric="MI[%s,%s,1,32,Regular,0.25]"
+            if do_repro == True:
+                linear_metric="GC[%s,%s,1,1,Regular,0.25]"
+    
+            if do_quick == True:
+                syn_convergence = "[100x70x50x0,1e-6,10]"
+                metric_parameter = 32
+                syn_metric = "MI[%s,%s,1,%s]" % (f, m, metric_parameter)
+            else:
+                metric_parameter = 2
+                syn_convergence = "[100x70x50x20,1e-6,10]"
+                syn_metric = "CC[%s,%s,1,%s]" % (f, m, metric_parameter)
+            syn_shrink_factors = "8x4x2x1"
+            syn_smoothing_sigmas = "3x2x1x0vox"
+    
+            if do_quick == True and do_repro == True:
+                syn_convergence = "[100x70x50x0,1e-6,10]"
+                metric_parameter = 2
+                syn_metric = "CC[%s,%s,1,%s]" % (f, m, metric_parameter)
+    
+            if random_seed is None and do_repro == True:
+                random_seed = str( 1 )
+    
+            tx = "Rigid"
+            if subtype_of_transform == "t":
+                tx = "Translation"
+    
+            rigid_stage = [
+                "--transform",
+                tx + "[0.1]",
+                "--metric",
+                linear_metric % (f, m),
+                "--convergence",
+                rigid_convergence,
+                "--shrink-factors",
+                rigid_shrink_factors,
+                "--smoothing-sigmas",
+                rigid_smoothing_sigmas,
+            ]
+    
+            affine_stage = [
+                "--transform",
+                "Affine[0.1]",
+                "--metric",
+                linear_metric % (f, m),
+                "--convergence",
+                affine_convergence,
+                "--shrink-factors",
+                affine_shrink_factors,
+                "--smoothing-sigmas",
+                affine_smoothing_sigmas,
+            ]
+    
+            if subtype_of_transform == "sr" or subtype_of_transform == "br":
+                if do_quick == True:
+                    syn_convergence = "[50x0,1e-6,10]"
+                else:
+                    syn_convergence = "[50x20,1e-6,10]"
+                syn_shrink_factors = "2x1"
+                syn_smoothing_sigmas = "1x0vox"
+    
+            syn_stage = [
+                "--metric",
+                syn_metric,
+            ]
+    
+            if multivariate_extras is not None:
+                for kk in range(len(multivariate_extras)):
+                    syn_stage.append("--metric")
+                    metricname = multivariate_extras[kk][0]
+                    metricfixed = serializer.get_pointer_string(
+                        multivariate_extras[kk][1]
+                    )
+                    metricmov = serializer.get_pointer_string(
+                        multivariate_extras[kk][2]
+                    )
+                    metricWeight = multivariate_extras[kk][3]
+                    metricSampling = multivariate_extras[kk][4]
+                    metricString = "%s[%s,%s,%s,%s]" % (
+                        metricname,
+                        metricfixed,
+                        metricmov,
+                        metricWeight,
+                        metricSampling,
+                    )
+                    syn_stage.append(metricString)
+    
+            syn_stage.append("--convergence")
+            syn_stage.append(syn_convergence)
+            syn_stage.append("--shrink-factors")
+            syn_stage.append(syn_shrink_factors)
+            syn_stage.append("--smoothing-sigmas")
+            syn_stage.append(syn_smoothing_sigmas)
+    
+            if (
+                subtype_of_transform == "b"
+                or subtype_of_transform == "br"
+                or subtype_of_transform == "bo"
+            ):
+                syn_stage.insert(0, "BSplineSyN[0.1," + str(spline_distance) + ",0,3]")
+                syn_stage.insert(0, "--transform")
+    
+            if (
+                subtype_of_transform == "s"
+                or subtype_of_transform == "sr"
+                or subtype_of_transform == "so"
+            ):
+                syn_stage.insert(0, "SyN[0.1,3,0]")
+                syn_stage.insert(0, "--transform")
+    
+            args = [
+                "-d",
+                str(fixed.dimension),
+                "-r",
+                initx,
+                "-o",
+                "[%s,%s,%s]" % (outprefix, wmo, wfo),
+            ]
+    
+            if subtype_of_transform == "r" or subtype_of_transform == "t":
+                args.append(rigid_stage)
+            if subtype_of_transform == "a":
+                args.append(rigid_stage)
+                args.append(affine_stage)
+            if subtype_of_transform == "b" or subtype_of_transform == "s":
+                args.append(rigid_stage)
+                args.append(affine_stage)
+                args.append(syn_stage)
+            if subtype_of_transform == "br" or subtype_of_transform == "sr":
+                args.append(rigid_stage)
+                args.append(syn_stage)
+            if subtype_of_transform == "bo" or subtype_of_transform == "so":
+                args.append(syn_stage)
+    
+            if maskopt is not None:
+                args.append("-x")
+                args.append(maskopt)
+            else:
+                args.append("-x")
+                args.append("[NA,NA]")
+    
+            args = list(
+                itertools.chain.from_iterable(
+                    itertools.repeat(x, 1) if isinstance(x, str) else x
+                    for x in args
+                )
+            )
+    
+        # ------------------------------------------------------------
+    
+        if random_seed is not None:
+            args.append("--random-seed")
+            args.append(random_seed)
+    
+        if restrict_transformation is not None:
+            args.append("-g")
+            args.append(restrict_transformationchar)
+    
+        args.append("--float")
         args.append("1")
-
-    processed_args = utils._int_antsProcessArguments(args)
-    libfn = utils.get_lib_fn("antsRegistration")
-    if verbose:
-        print("antsRegistration " + ' '.join(processed_args))
-    reg_exit = libfn(processed_args)
-    if (reg_exit != 0):
-        raise RuntimeError(f"Registration failed with error code {reg_exit}")
+        args.append("--write-composite-transform")
+        args.append(write_composite_transform * 1)
+        if verbose:
+            args.append("-v")
+            args.append("1")
+            
+        processed_args = serializer.int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn("antsRegistration")
+        if verbose:
+            print("antsRegistration " + ' '.join(processed_args))
+        reg_exit = libfn(processed_args)
+        if (reg_exit != 0):
+            raise RuntimeError(f"Registration failed with error code {reg_exit}")
+    
     afffns = glob.glob(outprefix + "*" + "[0-9]GenericAffine.mat")
     fwarpfns = glob.glob(outprefix + "*" + "[0-9]Warp.nii.gz")
     iwarpfns = glob.glob(outprefix + "*" + "[0-9]InverseWarp.nii.gz")

--- a/ants/segmentation/atropos.py
+++ b/ants/segmentation/atropos.py
@@ -101,42 +101,44 @@ def atropos(a, x, i='Kmeans[3]', m='[0.2,1x1]', c='[5,0]',
         outimg = a.clone('unsigned int')
 
     mydim = outimg.dimension
-    outs = '[%s,%s]' % (utils._ptrstr(outimg.pointer), probs)
-    mymask = x.clone('unsigned int')
-
-    if (not isinstance(a, (list,tuple))) or (len(a) == 1):
-        myargs = {
-            'd': mydim,
-            'a': a,
-            'm-MULTINAME-0': m,
-            'o': outs,
-            'c': c,
-            'm-MULTINAME-1': m,
-            'i': i,
-            'x': mymask
-        }
-        for k, v in kwargs.items():
-            myargs[k] = v
-
-    elif isinstance(a, (list, tuple)):
-        if len(a) > 6:
-            print('more than 6 input images not really supported, using first 6')
-            a = a[:6]
-        myargs = {
-            'd': mydim,
-            'm-MULTINAME-0': m,
-            'o': outs,
-            'c': c,
-            'm-MULTINAME-1': m,
-            'i': i,
-            'x': mymask
-        }
-        for aa_idx, aa in enumerate(a):
-            myargs['a-MULTINAME-%i'%aa_idx] = aa
-
-    processed_args = utils._int_antsProcessArguments(myargs)
-    libfn = utils.get_lib_fn('Atropos')
-    retval = libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        outs = '[%s,%s]' % (serializer.get_pointer_string(outimg), probs)
+        mymask = x.clone('unsigned int')
+    
+        if (not isinstance(a, (list,tuple))) or (len(a) == 1):
+            myargs = {
+                'd': mydim,
+                'a': a,
+                'm-MULTINAME-0': m,
+                'o': outs,
+                'c': c,
+                'm-MULTINAME-1': m,
+                'i': i,
+                'x': mymask
+            }
+            for k, v in kwargs.items():
+                myargs[k] = v
+    
+        elif isinstance(a, (list, tuple)):
+            if len(a) > 6:
+                print('more than 6 input images not really supported, using first 6')
+                a = a[:6]
+            myargs = {
+                'd': mydim,
+                'm-MULTINAME-0': m,
+                'o': outs,
+                'c': c,
+                'm-MULTINAME-1': m,
+                'i': i,
+                'x': mymask
+            }
+            for aa_idx, aa in enumerate(a):
+                myargs['a-MULTINAME-%i'%aa_idx] = aa
+    
+        processed_args = serializer.int_antsProcessArguments(myargs)
+        libfn = utils.get_lib_fn('Atropos')
+        retval = libfn(processed_args)
 
     if retval != 0:
         warnings.warn('ERROR: Non-zero exit status!')

--- a/ants/segmentation/kelly_kapowski.py
+++ b/ants/segmentation/kelly_kapowski.py
@@ -70,10 +70,10 @@ def kelly_kapowski(s, g, w, its=45, r=0.025, m=1.5, **kwargs):
     for k, v in kwargs.items():
         kellargs[k] = v
 
-    processed_kellargs = utils._int_antsProcessArguments(kellargs)
-
-    libfn = utils.get_lib_fn('KellyKapowski')
-    libfn(processed_kellargs)
+    with utils.ANTsSerializer() as serializer:
+        processed_kellargs = serializer.int_antsProcessArguments(kellargs)
+        libfn = utils.get_lib_fn('KellyKapowski')
+        libfn(processed_kellargs)
     return outimg
 
 

--- a/ants/segmentation/label_geometry_measures.py
+++ b/ants/segmentation/label_geometry_measures.py
@@ -38,9 +38,11 @@ def label_geometry_measures(label_image, intensity_image=None):
     outcsv = mktemp(suffix='.csv')
 
     veccer = [label_image.dimension, label_image, intensity_image, outcsv]
-    veccer_processed = utils._int_antsProcessArguments(veccer)
-    libfn = utils.get_lib_fn('LabelGeometryMeasures')
-    pp = libfn(veccer_processed)
+    
+    with utils.ANTsSerializer() as serializer:
+        veccer_processed = serializer.int_antsProcessArguments(veccer)
+        libfn = utils.get_lib_fn('LabelGeometryMeasures')
+        pp = libfn(veccer_processed)
     pp = pd.read_csv(outcsv)
     pp['Label'] = np.sort(np.unique(label_image[label_image>0])).astype('int')
     pp_cols = pp.columns.values

--- a/ants/utils/bias_correction.py
+++ b/ants/utils/bias_correction.py
@@ -35,9 +35,11 @@ def n3_bias_field_correction(image, downsample_factor=3):
     """
     outimage = image.clone()
     args = [image.dimension, image, outimage, downsample_factor]
-    processed_args = pargs._int_antsProcessArguments(args)
-    libfn = utils.get_lib_fn("N3BiasFieldCorrection")
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer.int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn("N3BiasFieldCorrection")
+        libfn(processed_args)
     return outimage
 
 def n3_bias_field_correction2(
@@ -133,26 +135,29 @@ def n3_bias_field_correction2(
 
     outimage = image.clone("float")
     outbiasfield = image.clone("float")
-    i = utils.get_pointer_string(outimage)
-    b = utils.get_pointer_string(outbiasfield)
-    output = "[%s,%s]" % (i, b)
-
-    kwargs = {
-        "d": outimage.dimension,
-        "i": image,
-        "w": weight_mask,
-        "s": N3_SHRINK_FACTOR_1,
-        "c": N3_CONVERGENCE_1,
-        "b": N3_BSPLINE_PARAMS,
-        "x": mask,
-        "r": int(rescale_intensities),
-        "o": output,
-        "v": int(verbose),
-    }
-
-    processed_args = pargs._int_antsProcessArguments(kwargs)
-    libfn = utils.get_lib_fn("N3BiasFieldCorrection")
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        i = serializer.get_pointer_string(outimage)
+        b = serializer.get_pointer_string(outbiasfield)
+        output = "[%s,%s]" % (i, b)
+        
+        kwargs = {
+            "d": outimage.dimension,
+            "i": image,
+            "w": weight_mask,
+            "s": N3_SHRINK_FACTOR_1,
+            "c": N3_CONVERGENCE_1,
+            "b": N3_BSPLINE_PARAMS,
+            "x": mask,
+            "r": int(rescale_intensities),
+            "o": output,
+            "v": int(verbose),
+        }
+        
+        with utils.ANTsSerializer() as serializer:
+            processed_args = serializer.int_antsProcessArguments(kwargs)
+            libfn = utils.get_lib_fn("N3BiasFieldCorrection")
+            libfn(processed_args)
     if return_bias_field == True:
         return outbiasfield
     else:
@@ -247,26 +252,29 @@ def n4_bias_field_correction(
 
     outimage = image.clone("float")
     outbiasfield = image.clone("float")
-    i = utils.get_pointer_string(outimage)
-    b = utils.get_pointer_string(outbiasfield)
-    output = "[%s,%s]" % (i, b)
-
-    kwargs = {
-        "d": outimage.dimension,
-        "i": image,
-        "w": weight_mask,
-        "s": N4_SHRINK_FACTOR_1,
-        "c": N4_CONVERGENCE_1,
-        "b": N4_BSPLINE_PARAMS,
-        "x": mask,
-        "r": int(rescale_intensities),
-        "o": output,
-        "v": int(verbose),
-    }
-
-    processed_args = pargs._int_antsProcessArguments(kwargs)
-    libfn = utils.get_lib_fn("N4BiasFieldCorrection")
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        i = serializer.get_pointer_string(outimage)
+        b = serializer.get_pointer_string(outbiasfield)
+        output = "[%s,%s]" % (i, b)
+        
+        kwargs = {
+            "d": outimage.dimension,
+            "i": image,
+            "w": weight_mask,
+            "s": N4_SHRINK_FACTOR_1,
+            "c": N4_CONVERGENCE_1,
+            "b": N4_BSPLINE_PARAMS,
+            "x": mask,
+            "r": int(rescale_intensities),
+            "o": output,
+            "v": int(verbose),
+        }
+        
+        with utils.ANTsSerializer() as serializer:
+            processed_args = serializer.int_antsProcessArguments(kwargs)
+            libfn = utils.get_lib_fn("N4BiasFieldCorrection")
+            libfn(processed_args)
     if return_bias_field == True:
         return outbiasfield
     else:

--- a/ants/utils/denoise_image.py
+++ b/ants/utils/denoise_image.py
@@ -77,8 +77,9 @@ def denoise_image(
             "o": outimage,
             "v": v,
         }
-
-    processed_args = pargs._int_antsProcessArguments(myargs)
-    libfn = utils.get_lib_fn("DenoiseImage")
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer.int_antsProcessArguments(myargs)
+        libfn = utils.get_lib_fn("DenoiseImage")
+        libfn(processed_args)
     return outimage.clone(inpixeltype)

--- a/ants/utils/iMath.py
+++ b/ants/utils/iMath.py
@@ -31,7 +31,6 @@ __all__ = ['iMath',
            'iMath_propagate_labels_through_mask']
 
 
-from .process_args import _int_antsProcessArguments
 from .. import utils
 
 _iMathOps = {'FillHoles',
@@ -100,10 +99,11 @@ def iMath(image, operation, *args):
     imagedim = image.dimension
     outimage = image.clone()
     args = [imagedim, outimage, operation, image] + [a for a in args]
-    processed_args = _int_antsProcessArguments(args)
-
-    libfn = utils.get_lib_fn('iMath')
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer.int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn('iMath')
+        libfn(processed_args)
     return outimage
 image_math = iMath
 

--- a/ants/utils/label_clusters.py
+++ b/ants/utils/label_clusters.py
@@ -4,7 +4,6 @@
 __all__ = ['label_clusters']
 
 from .. import utils
-from .process_args import _int_antsProcessArguments
 from .threshold_image import threshold_image
 
 
@@ -47,7 +46,8 @@ def label_clusters(image, min_cluster_size=50, min_thresh=1e-6, max_thresh=1, fu
     clust = threshold_image(image, min_thresh, max_thresh)
     temp = int(fully_connected)
     args = [dim, clust, clust, min_cluster_size, temp]
-    processed_args = _int_antsProcessArguments(args)
-    libfn = utils.get_lib_fn('LabelClustersUniquely')
-    libfn(processed_args)
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer.int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn('LabelClustersUniquely')
+        libfn(processed_args)
     return clust

--- a/ants/utils/process_args.py
+++ b/ants/utils/process_args.py
@@ -6,11 +6,14 @@ __all__ = [
     "ANTsSerializer",
     "short_ptype",
     "get_lib_fn",
+    "get_pointer_string",
+    "_int_antsProcessArguments"
 ]
 
 import platform
 import os
 import atexit
+import warnings
 from ..core import ants_image as iio
 from .. import lib
 
@@ -128,3 +131,26 @@ class ANTsSerializer(object):
         return p_args
     
 
+# Be backward compatible in case users are using these functions
+# in their own code
+def get_pointer_string(image):
+    '''
+    get_pointer_string is pending deprecation. Please use the followings instead:
+    
+    with ANTsSerializer() as serializer:
+        serializer.get_pointer_string(image)
+    '''
+    warnings.warn('get_pointer_string is pending deprecation. Please use the followings instead:\nwith ANTsSerializer() as serializer:\n  serializer.get_pointer_string(image)', PendingDeprecationWarning)
+    serializer = ANTsSerializer()
+    return serializer.get_pointer_string(image)
+
+def _int_antsProcessArguments(args):
+    '''
+    _int_antsProcessArguments is pending deprecation. Please use the followings instead:
+    
+    with ANTsSerializer() as serializer:
+        serializer.int_antsProcessArguments(args)
+    '''
+    warnings.warn('_int_antsProcessArguments is pending deprecation. Please use the followings instead:\nwith ANTsSerializer() as serializer:\n  serializer.int_antsProcessArguments(args)', PendingDeprecationWarning)
+    serializer = ANTsSerializer()
+    return serializer.int_antsProcessArguments(args)

--- a/ants/utils/process_args.py
+++ b/ants/utils/process_args.py
@@ -3,13 +3,14 @@
 
 
 __all__ = [
-    "get_pointer_string",
+    "ANTsSerializer",
     "short_ptype",
-    "_ptrstr",
-    "_int_antsProcessArguments",
     "get_lib_fn",
 ]
 
+import platform
+import os
+import atexit
 from ..core import ants_image as iio
 from .. import lib
 
@@ -20,6 +21,24 @@ _short_ptype_map = {
     "double": "D",
 }
 
+temporary_folder = None
+
+def temp_dir():
+    global temporary_folder
+    if temporary_folder is None or not os.path.exists(temporary_folder):
+        temporary_folder = tempfile.mkdtemp(prefix="ANTsPyTmp")
+    return temporary_folder
+
+def temp_file(suffix=None, prefix=None, dir=None):
+    if dir is None:
+        dir = temp_dir()
+    return tempfile.mktemp(suffix=suffix, prefix=prefix, dir=dir)
+
+@atexit.register
+def clear_temp_dir():
+    if temporary_folder is not None and os.path.exists(temporary_folder):
+        os.removedirs(temporary_folder)
+
 
 def short_ptype(pixeltype):
     return _short_ptype_map[pixeltype]
@@ -28,60 +47,84 @@ def short_ptype(pixeltype):
 def get_lib_fn(string):
     return lib.__dict__[string]
 
-
 def _ptrstr(pointer):
     """ get string representation of a py::capsule (aka pointer) """
     libfn = get_lib_fn("ptrstr")
     return libfn(pointer)
 
-
-def get_pointer_string(image):
-    return _ptrstr(image.pointer)
-
-
-def _int_antsProcessArguments(args):
-    """
-    Needs to be better validated.
-    """
-    p_args = []
-    if isinstance(args, dict):
-        for argname, argval in args.items():
-            if "-MULTINAME-" in argname:
-                # have this little hack because python doesnt support
-                # multiple dict entries w/ the same key like R lists
-                argname = argname[: argname.find("-MULTINAME-")]
-            if argval is not None:
-                if len(argname) > 1:
-                    p_args.append("--%s" % argname)
+class ANTsSerializer(object):
+    def __init__(self):
+        self._temp_files = []
+        self._os = platform.system()
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exception_type, exception_value, traceback):
+        # There is no need to handle exception type
+        for tmpfile in self._temp_files:
+            if os.path.exists(tmpfile):
+                os.remove(tmpfile)
+        # clear the list, might be overkilling
+        self._temp_files.clear();
+    
+    def get_pointer_string(self, image):
+        if self._os == "Windows":
+            # save to a temporary file
+            tfile = temp_file(suffix=".nii.gz", prefix="ANTsSerializer")
+            # just to be safe in case backslashes are not properly quoted
+            tfile = os.path.normpath(tfile).replace(os.sep, '/')
+            # add this file first in case the file is created before errors
+            self._temp_files.append(tfile)
+            image.to_file(tfile)
+        else:
+            tfile = _ptrstr(image.pointer)
+        return tfile
+    
+    def int_antsProcessArguments(self, args):
+        """
+        Needs to be better validated.
+        """
+        p_args = []
+        if isinstance(args, dict):
+            for argname, argval in args.items():
+                if "-MULTINAME-" in argname:
+                    # have this little hack because python doesnt support
+                    # multiple dict entries w/ the same key like R lists
+                    argname = argname[: argname.find("-MULTINAME-")]
+                if argval is not None:
+                    if len(argname) > 1:
+                        p_args.append("--%s" % argname)
+                    else:
+                        p_args.append("-%s" % argname)
+                    
+                    if isinstance(argval, iio.ANTsImage):
+                        p_args.append(self.get_pointer_string(argval))
+                    elif isinstance(argval, list):
+                        for av in argval:
+                            if isinstance(av, iio.ANTsImage):
+                                av = self.get_pointer_string(av)
+                            elif str(arg) == "True":
+                                av = str(1)
+                            elif str(arg) == "False":
+                                av = str(0)
+                            p_args.append(av)
+                    else:
+                        p_args.append(str(argval))
+        elif isinstance(args, list):
+            for arg in args:
+                if isinstance(arg, iio.ANTsImage):
+                    pointer_string = self.get_pointer_string(arg)
+                    p_arg = pointer_string
+                elif arg is None:
+                    pass
+                elif str(arg) == "True":
+                    p_arg = str(1)
+                elif str(arg) == "False":
+                    p_arg = str(0)
                 else:
-                    p_args.append("-%s" % argname)
+                    p_arg = str(arg)
+                p_args.append(p_arg)
+        return p_args
+    
 
-                if isinstance(argval, iio.ANTsImage):
-                    p_args.append(_ptrstr(argval.pointer))
-                elif isinstance(argval, list):
-                    for av in argval:
-                        if isinstance(av, iio.ANTsImage):
-                            av = _ptrstr(av.pointer)
-                        elif str(arg) == "True":
-                            av = str(1)
-                        elif str(arg) == "False":
-                            av = str(0)
-                        p_args.append(av)
-                else:
-                    p_args.append(str(argval))
-
-    elif isinstance(args, list):
-        for arg in args:
-            if isinstance(arg, iio.ANTsImage):
-                pointer_string = _ptrstr(arg.pointer)
-                p_arg = pointer_string
-            elif arg is None:
-                pass
-            elif str(arg) == "True":
-                p_arg = str(1)
-            elif str(arg) == "False":
-                p_arg = str(0)
-            else:
-                p_arg = str(arg)
-            p_args.append(p_arg)
-    return p_args

--- a/ants/utils/scalar_rgb_vector.py
+++ b/ants/utils/scalar_rgb_vector.py
@@ -60,9 +60,10 @@ def scalar_to_rgb(image, mask=None, filename=None, cmap='red', custom_colormap_f
         vtk_lookup_table = mktemp(suffix='.csv')
         args.append('vtkLookupTable=%s' % vtk_lookup_table)
     
-    processed_args = utils._int_antsProcessArguments(args)
-    libfn = utils.get_lib_fn('ConvertScalarImageToRGB')
-    libfn(processed_args)
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer.int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn('ConvertScalarImageToRGB')
+        libfn(processed_args)
 
     if file_is_temp:
         outimg = iio2.image_read(filename, pixeltype=None)

--- a/ants/utils/threshold_image.py
+++ b/ants/utils/threshold_image.py
@@ -3,7 +3,6 @@
 
 __all__ = ['threshold_image']
 
-from .process_args import _int_antsProcessArguments
 from .. import utils
 
 
@@ -51,9 +50,11 @@ def threshold_image(image, low_thresh=None, high_thresh=None, inval=1, outval=0,
     dim = image.dimension
     outimage = image.clone()
     args = [dim, image, outimage, low_thresh, high_thresh, inval, outval]
-    processed_args = _int_antsProcessArguments(args)
-    libfn = utils.get_lib_fn('ThresholdImage')
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        processed_args = utils.int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn('ThresholdImage')
+        libfn(processed_args)
     if binary:
         return outimage
     else:

--- a/ants/viz/create_tiled_mosaic.py
+++ b/ants/viz/create_tiled_mosaic.py
@@ -126,7 +126,7 @@ def create_tiled_mosaic(image, rgb=None, mask=None, overlay=None,
         'd': direction
     }
 
-    processed_args = utils._int_antsProcessArguments(args)
+    processed_args = utils.int_antsProcessArguments(args)
 
     libfn = utils.get_lib_fn('CreateTiledMosaic')
 

--- a/ants/viz/create_tiled_mosaic.py
+++ b/ants/viz/create_tiled_mosaic.py
@@ -126,11 +126,10 @@ def create_tiled_mosaic(image, rgb=None, mask=None, overlay=None,
         'd': direction
     }
 
-    processed_args = utils.int_antsProcessArguments(args)
-
-    libfn = utils.get_lib_fn('CreateTiledMosaic')
-
-    libfn(processed_args)
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer._int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn('CreateTiledMosaic')
+        libfn(processed_args)
 
     outimage = Image.open(output)
     if output_is_temp:

--- a/ants/viz/volume.py
+++ b/ants/viz/volume.py
@@ -341,9 +341,11 @@ def convert_scalar_image_to_rgb(dimension, img, outimg, mask, colormap='red', cu
 
     args = [dimension, img, outimg, mask, colormap, custom_colormap_file,
             min_input, max_input, min_rgb_output, max_rgb_output, vtk_lookup_table]
-    processed_args = utils._int_antsProcessArguments(args)
-    libfn = utils.get_lib_fn('ConvertScalarImageToRGB')
-    libfn(processed_args)
+    
+    with utils.ANTsSerializer() as serializer:
+        processed_args = serializer.int_antsProcessArguments(args)
+        libfn = utils.get_lib_fn('ConvertScalarImageToRGB')
+        libfn(processed_args)
 
 
 def _vol_single(image, outfile, magnification, dilation, inflation, alpha, overlay, overlay_mask, 


### PR DESCRIPTION
Added `ANTsSerializer` in `process_args.py` to fix https://github.com/ANTsX/ANTsPy/issues/429 on Windows

It handles image pointers differently on windows: ANTsImages are saved to temporary file instead of returning memory pointers. However, the temporary files need to be cleaned after running command.

This class requires `with` syntax:

```py
with utils.ANTsSerializer() as serializer:
	out = serializer.get_pointer_string(image)
	...
	params = int_antsProcessArguments(args)
	libfn(params)
```

I can't compile ANTsPy from source on my machine (neither osx nor windows). Calling for help if anyone can test the code : )
