### PR TITLE
ENH: Check for test failures on windows

### DIFF
--- a/tests/run_tests.bat
+++ b/tests/run_tests.bat
@@ -2,18 +2,28 @@ SET PYCMD=python
 pushd "tests"
 echo "Running core tests"
 %PYCMD% test_core_ants_image.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 %PYCMD% test_core_ants_image_io.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 %PYCMD% test_core_ants_transform.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 %PYCMD% test_core_ants_transform_io.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 %PYCMD% test_core_ants_metric.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 echo "Running learn tests"
 %PYCMD% test_learn.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 echo "Running registation tests"
 %PYCMD% test_registation.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 echo "Running segmentation tests"
 %PYCMD% test_segmentation.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 echo "Running utils tests"
 %PYCMD% test_utils.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 echo "Running bug tests"
 %PYCMD% test_bugs.py %@%
+if ( $LastExitCode -ne 0 ) { exit 1 }
 popd


### PR DESCRIPTION
As part of my quest to get ANTsPy working  on Windows, I noticed that the windows test script will return 0 on failure, for example

https://github.com/cookpa/ANTsPy/actions/runs/4482864793/jobs/7881443873

Try to fix this by testing the exit code after every unit test