### PR TITLE
Support for a slightly more flexible use of masks

### DIFF
--- a/ants/registration/interface.py
+++ b/ants/registration/interface.py
@@ -406,7 +406,7 @@ def registration(
         mask_scale = mask_scale / mask_scale.max() * 255.0
         charmask = mask_scale.clone("unsigned char")
         f_mask_str = utils.get_pointer_string(charmask)
-    else
+    else:
         f_mask_str = "NA"
     
     if moving_mask is not None:
@@ -414,7 +414,7 @@ def registration(
         moving_mask_scale = moving_mask_scale / moving_mask_scale.max() * 255.0
         moving_charmask = moving_mask_scale.clone("unsigned char")
         m_mask_str = utils.get_pointer_string(moving_charmask)
-    else
+    else:
         m_mask_str = "NA"
     
     maskopt = "[%s,%s]" % (f_mask_str, m_mask_str)


### PR DESCRIPTION
* Added two optional inputs to `ants.registration`:
    - `moving_mask` - a mask that applies to the moving image (default: `None`)
    - `mask_all_stages` - if `True`, mask(s) are applied during all stages of registration (eg Affine *and* SyN). Otherwise (default) they are only applied at the last stage (usually SyN) as was the original behaviour.

* Slightly simplified the code for providing masks (or `"NA"` if none is provided) as arguments,