### PR TITLE
Similarity option typo made "ANTSNeighborhoodCorrelation" unreachable

### DIFF
--- a/ants/core/ants_metric_io.py
+++ b/ants/core/ants_metric_io.py
@@ -15,7 +15,7 @@ from . import ants_metric as mio
 
 _supported_metrics = {'MeanSquares',
                     'MattesMutualInformation',
-                    'ANTsNeighborhoodCorrelation',
+                    'ANTSNeighborhoodCorrelation',
                     'Correlation',
                     'Demons',
                     'JointHistogramMutualInformation'}
@@ -50,7 +50,7 @@ def create_ants_metric(fixed,
         options:
             MeanSquares
             MattesMutualInformation
-            ANTsNeighborhoodCorrelation
+            ANTSNeighborhoodCorrelation
             Correlation
             Demons
             JointHistogramMutualInformation

--- a/ants/core/ants_metric_io.py
+++ b/ants/core/ants_metric_io.py
@@ -35,7 +35,7 @@ def new_ants_metric(dimension=3, precision='float', metric_type='MeanSquares'):
     return ants_metric
 
 
-def create_ants_metric(fixed, 
+def create_ants_metric(fixed,
                         moving,
                         metric_type='MeanSquares',
                         fixed_mask=None,
@@ -69,13 +69,13 @@ def create_ants_metric(fixed,
 
     if metric_type not in _supported_metrics:
         raise ValueError('metric_type must be one of %s' % _supported_metrics)
-    
+
     if (dimension < 2) or (dimension > 4):
         raise ValueError('unsupported dimension %i' % dimension)
 
     if not isinstance(moving, iio.ANTsImage):
         raise ValueError('invalid moving image')
-    
+
     if moving.dimension != dimension:
         raise ValueError('Fixed and Moving images must have same dimension')
 
@@ -83,7 +83,7 @@ def create_ants_metric(fixed,
         raise ValueError('invalid fixed image')
 
     fixed = fixed.clone('float')
-    moving = moving.clone('float') 
+    moving = moving.clone('float')
 
     libfn = utils.get_lib_fn('create_ants_metricF%i' % dimension)
     metric = libfn(pixeltype, dimension, metric_type, is_vector, fixed.pointer, moving.pointer)

--- a/ants/lib/LOCAL_antsImageToImageMetric.h
+++ b/ants/lib/LOCAL_antsImageToImageMetric.h
@@ -335,7 +335,7 @@ ANTsImageToImageMetric< MetricBaseType > create_ants_metric(std::string pixeltyp
     MetricBasePointerType baseMetric = dynamic_cast<MetricBaseType *>( metric.GetPointer() );
     return( wrap_metric< MetricBaseType >( baseMetric ) );
   }
-  else if ( metrictype == "ANTsNeighborhoodCorrelation" ) {
+  else if ( metrictype == "ANTSNeighborhoodCorrelation" ) {
     typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<ImageType,ImageType> MetricType;
     typename MetricType::Pointer metric = MetricType::New();
     metric->SetFixedImage( fixed );

--- a/ants/lib/LOCAL_antsImageToImageMetric.h
+++ b/ants/lib/LOCAL_antsImageToImageMetric.h
@@ -387,5 +387,15 @@ ANTsImageToImageMetric< MetricBaseType > create_ants_metric(std::string pixeltyp
     return( wrap_metric< MetricBaseType >( baseMetric ) );
   }
 
-  return nullptr;
+  // python code should prevent us getting here by checking for known metric types
+  std::cerr << "Unsupported metric type requested: " << metrictype << std::endl;
+  std::cerr << "Returning JointHistogramMutualInformation metric" << std::endl;
+
+  typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType,ImageType> MetricType;
+  typename MetricType::Pointer metric = MetricType::New();
+  metric->SetFixedImage( fixed );
+  metric->SetMovingImage( moving );
+  MetricBasePointerType baseMetric = dynamic_cast<MetricBaseType *>( metric.GetPointer() );
+  return( wrap_metric< MetricBaseType >( baseMetric ) );
+
 }

--- a/ants/lib/LOCAL_antsImageToImageMetric.h
+++ b/ants/lib/LOCAL_antsImageToImageMetric.h
@@ -318,7 +318,6 @@ ANTsImageToImageMetric< MetricBaseType > create_ants_metric(std::string pixeltyp
 
     typedef typename MetricBaseType::Pointer  MetricBasePointerType;
 
-  //supportedTypes = c("MeanSquares", "MattesMutualInformation", "ANTSNeighborhoodCorrelation", "Correlation", "Demons", "JointHistogramMutualInformation")
   if ( metrictype == "MeanSquares" ) {
     typedef itk::MeanSquaresImageToImageMetricv4<ImageType,ImageType> MetricType;
     typename MetricType::Pointer metric = MetricType::New();
@@ -336,7 +335,7 @@ ANTsImageToImageMetric< MetricBaseType > create_ants_metric(std::string pixeltyp
     MetricBasePointerType baseMetric = dynamic_cast<MetricBaseType *>( metric.GetPointer() );
     return( wrap_metric< MetricBaseType >( baseMetric ) );
   }
-  else if ( metrictype == "ANTSNeighborhoodCorrelation" ) {
+  else if ( metrictype == "ANTsNeighborhoodCorrelation" ) {
     typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<ImageType,ImageType> MetricType;
     typename MetricType::Pointer metric = MetricType::New();
     metric->SetFixedImage( fixed );
@@ -388,8 +387,5 @@ ANTsImageToImageMetric< MetricBaseType > create_ants_metric(std::string pixeltyp
     return( wrap_metric< MetricBaseType >( baseMetric ) );
   }
 
-  typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType,ImageType> MetricType;
-  typename MetricType::Pointer metric = MetricType::New();
-  MetricBasePointerType baseMetric = dynamic_cast<MetricBaseType *>( metric.GetPointer() );
-  return( wrap_metric< MetricBaseType >( baseMetric ) );
+  return nullptr;
 }

--- a/ants/utils/image_similarity.py
+++ b/ants/utils/image_similarity.py
@@ -5,47 +5,47 @@ __all__ = ['image_similarity']
 from ..core import ants_metric as mio
 from ..core import ants_metric_io as mio2
 
-def image_similarity(fixed_image, moving_image, metric_type='MeanSquares', 
-                    fixed_mask=None, moving_mask=None, 
+def image_similarity(fixed_image, moving_image, metric_type='MeanSquares',
+                    fixed_mask=None, moving_mask=None,
                     sampling_strategy='regular', sampling_percentage=1.):
     """
     Measure similarity between two images.
     NOTE: Similarity is actually returned as distance (i.e. dissimilarity)
     per ITK/ANTs convention. E.g. using Correlation metric, the similarity
     of an image with itself returns -1.
-    
+
     ANTsR function: `imageSimilarity`
 
     Arguments
     ---------
     fixed : ANTsImage
         the fixed image
-    
+
     moving : ANTsImage
         the moving image
-    
+
     metric_type : string
         image metric to calculate
             MeanSquares
             Correlation
-            ANTsNeighborhoodCorrelation
+            ANTSNeighborhoodCorrelation
             MattesMutualInformation
             JointHistogramMutualInformation
             Demons
-    
+
     fixed_mask : ANTsImage (optional)
         mask for the fixed image
-    
+
     moving_mask : ANTsImage (optional)
         mask for the moving image
-    
+
     sampling_strategy : string (optional)
         sampling strategy, default is full sampling
             None (Full sampling)
             random
             regular
-    
-    sampling_percentage : scalar 
+
+    sampling_percentage : scalar
         percentage of data to sample when calculating metric
         Must be between 0 and 1
 


### PR DESCRIPTION
`utils.image_similarity` was returning MI metric value instead.

Fixes #479