### PR TITLE
corrected docstrings for affine transformations

### DIFF
--- a/ants/contrib/sampling/affine2d.py
+++ b/ants/contrib/sampling/affine2d.py
@@ -29,7 +29,7 @@ class Translate2D(object):
 
     def __init__(self, translation, reference=None, lazy=False):
         """
-        Initialize a Shear2D object
+        Initialize a Translate2D object
 
         Arguments
         ---------
@@ -283,7 +283,7 @@ class RandomShear2D(object):
 
     def __init__(self, shear_range, reference=None, lazy=False):
         """
-        Initialize a RandomRotate2D object
+        Initialize a RandomShear2D object
 
         Arguments
         ---------

--- a/ants/contrib/sampling/affine3d.py
+++ b/ants/contrib/sampling/affine3d.py
@@ -29,7 +29,7 @@ class Translate3D(object):
 
     def __init__(self, translation, reference=None, lazy=False):
         """
-        Initialize a Shear3D object
+        Initialize a Translate3D object
 
         Arguments
         ---------
@@ -304,7 +304,7 @@ class RandomShear3D(object):
 
     def __init__(self, shear_range, reference=None, lazy=False):
         """
-        Initialize a RandomRotate3D object
+        Initialize a RandomShear3D object
 
         Arguments
         ---------
@@ -482,7 +482,7 @@ class Rotate3D(object):
 
 class RandomRotate3D(object):
     """
-    Apply a Rotated3D transform to an image, but with the zoom
+    Apply a Rotate3D transform to an image, but with the zoom
     parameters randomly generated from a user-specified range.
     The range is determined by a mean (first parameter) and standard deviation
     (second parameter) via calls to random.gauss.


### PR DESCRIPTION
Some of the docstrings for affine transformations were incorrect (probably due to copy-paste). This should hopefully be more clear!