### PR TITLE
COMP: Add support for Python 3.12

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -106,7 +106,7 @@ macos_arm64_task:
   name: build_macos_arm64_wheels
   # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-monterey-xcode
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
   env:
     matrix:
       - CIBW_BUILD: cp38-macosx_arm64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,6 +75,7 @@ linux_aarch64_task:
       - CIBW_BUILD: "cp39-manylinux*"
       - CIBW_BUILD: "cp310-manylinux*"
       - CIBW_BUILD: "cp311-manylinux*"
+      - CIBW_BUILD: "cp312-manylinux*"
     CIBW_ARCHS_LINUX: "auto"
     CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
     CIBW_BEFORE_ALL_LINUX: >
@@ -114,6 +115,7 @@ macos_arm64_task:
       - CIBW_BUILD: cp39-macosx_arm64
       - CIBW_BUILD: cp310-macosx_arm64
       - CIBW_BUILD: cp311-macosx_arm64
+      - CIBW_BUILD: cp312-macosx_arm64
     CIBW_ARCHS_MACOS: arm64
     CIBW_BEFORE_ALL_MACOS: >
       python -m ensurepip --upgrade &&

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,8 +69,6 @@ linux_aarch64_task:
   # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   env:
     matrix:
-      - CIBW_BUILD: "cp36-manylinux*"
-      - CIBW_BUILD: "cp37-manylinux*"
       - CIBW_BUILD: "cp38-manylinux*"
       - CIBW_BUILD: "cp39-manylinux*"
       - CIBW_BUILD: "cp310-manylinux*"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ env:
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_pipx_script:
-    - python -m pip install cibuildwheel==2.12.0 pipx jq
+    - python -m pip install cibuildwheel==2.16.2 pipx jq
     - python -m pipx ensurepath
   run_cibuildwheel_script:
     - cibuildwheel

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ env:
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_pipx_script:
-    - python -m pip install cibuildwheel==2.16.2 pipx jq
+    - python -m pip install cibuildwheel==2.16.2 jq pipx setuptools
     - python -m pipx ensurepath
   run_cibuildwheel_script:
     - cibuildwheel
@@ -78,7 +78,7 @@ linux_aarch64_task:
     CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
     CIBW_BEFORE_ALL_LINUX: >
       yum install -y gcc-c++ libpng-devel libpng &&
-      python -m pip install cmake ninja
+      python -m pip install cmake ninja setuptools
     CIBW_BEFORE_TEST: |
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
@@ -117,7 +117,7 @@ macos_arm64_task:
     CIBW_ARCHS_MACOS: arm64
     CIBW_BEFORE_ALL_MACOS: >
       python -m ensurepip --upgrade &&
-      conda install cmake ninja libpng
+      conda install cmake ninja libpng setuptools
     CIBW_BEFORE_TEST: |
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -106,7 +106,7 @@ macos_arm64_task:
   name: build_macos_arm64_wheels
   # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:latest
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:15
   env:
     matrix:
       - CIBW_BUILD: cp38-macosx_arm64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,10 +24,6 @@ jobs:
 
           # Windows 64-bit
           - os: windows-latest
-            python: '3.7'
-            cibw_python: 37
-            platform_id: win_amd64
-          - os: windows-latest
             python: '3.8'
             cibw_python: 38
             platform_id: win_amd64
@@ -50,10 +46,6 @@ jobs:
 
           # Linux 64-bit
           - os: ubuntu-latest
-            python: '3.7'
-            cibw_python: 37
-            platform_id: manylinux_x86_64
-          - os: ubuntu-latest
             python: '3.8'
             cibw_python: 38
             platform_id: manylinux_x86_64
@@ -75,11 +67,6 @@ jobs:
             platform_id: manylinux_x86_64
 
           # macOS on Intel 64-bit
-          - os: macos-latest
-            python: '3.7'
-            cibw_python: 37
-            arch: x86_64
-            platform_id: macosx_x86_64
           - os: macos-latest
             python: '3.8'
             cibw_python: 38

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,11 +116,11 @@ jobs:
           #   platform_id: macosx_arm64
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python host for cibuildwheel
         with:
           python-version: ${{ matrix.python }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,6 +43,10 @@ jobs:
             python: '3.11'
             cibw_python: 311
             platform_id: win_amd64
+          - os: windows-latest
+            python: '3.12'
+            cibw_python: 312
+            platform_id: win_amd64
 
           # Linux 64-bit
           - os: ubuntu-latest
@@ -64,6 +68,10 @@ jobs:
           - os: ubuntu-latest
             python: '3.11'
             cibw_python: 311
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: '3.12'
+            cibw_python: 312
             platform_id: manylinux_x86_64
 
           # macOS on Intel 64-bit
@@ -90,6 +98,11 @@ jobs:
           - os: macos-latest
             python: '3.11'
             cibw_python: 311
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: '3.12'
+            cibw_python: 312
             arch: x86_64
             platform_id: macosx_x86_64
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -131,7 +131,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.16.2
+        run: python -m pip install cibuildwheel==2.16.2 setuptools
 
       - name: Get package name and version (Linux / Mac)
         if: ${{ ! startsWith(matrix.os, 'windows-') }}
@@ -159,14 +159,14 @@ jobs:
 
           CIBW_BEFORE_ALL_LINUX: |
             yum install -y gcc-c++ libpng-devel libpng
-            python -m pip install cmake ninja
+            python -m pip install cmake ninja setuptools
 
           CIBW_BEFORE_ALL_WINDOWS: |
-            python -m pip install cmake ninja
+            python -m pip install cmake ninja setuptools
 
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_BEFORE_ALL_MACOS: |
-            python -m pip install cmake ninja
+            python -m pip install cmake ninja setuptools
 
           CIBW_ENVIRONMENT_MACOS: |
             CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -159,14 +159,14 @@ jobs:
 
           CIBW_BEFORE_ALL_LINUX: |
             yum install -y gcc-c++ libpng-devel libpng
-            pip install cmake ninja
+            python -m pip install cmake ninja
 
           CIBW_BEFORE_ALL_WINDOWS: |
-            pip install cmake ninja
+            python -m pip install cmake ninja
 
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_BEFORE_ALL_MACOS: |
-            pip install cmake ninja
+            python -m pip install cmake ninja
 
           CIBW_ENVIRONMENT_MACOS: |
             CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}
@@ -176,7 +176,7 @@ jobs:
       - name: Install and test (Linux / Mac)
         if: ${{ ! startsWith(matrix.os, 'windows-') }}
         run: |
-          pip install wheelhouse/cp${{ matrix.cibw_python }}-${{matrix.platform_id }}/*.whl
+          python -m pip install wheelhouse/cp${{ matrix.cibw_python }}-${{matrix.platform_id }}/*.whl
           tests/run_tests.sh
 
       - name: Install and test (Windows)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -144,7 +144,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.12.1
+        run: python -m pip install cibuildwheel==2.16.2
 
       - name: Get package name and version (Linux / Mac)
         if: ${{ ! startsWith(matrix.os, 'windows-') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Note: QEMU emulated ppc64le build might take ~6 hours
 
 # Use conda to resolve dependencies cross-platform
-FROM continuumio/miniconda3:23.5.2-0 as builder
+FROM debian:bookworm-slim as builder
 
 # install libpng to system for cross-architecture support
 # https://github.com/ANTsX/ANTs/issues/1069#issuecomment-681131938
@@ -11,12 +11,21 @@ RUN apt-get update && \
       apt-transport-https \
       bash \
       build-essential \
+      ca-certificates \
       git \
-      libpng-dev
+      libpng-dev \
+      wget
+
+# install miniconda3
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-Linux-x86_64.sh \
+    && /bin/bash Miniconda3-py310_23.11.0-1-Linux-x86_64.sh -b -p /opt/conda \
+    && rm Miniconda3-py310_23.11.0-1-Linux-x86_64.sh
+ENV PATH=/opt/conda/bin:$PATH
 
 # install cmake binary using conda for multi-arch support
 # apt install fails because libssl1.0.0 is not available for newer Debian
-RUN conda install -c anaconda cmake
+RUN conda update -c defaults conda
+RUN conda install -c conda-forge cmake
 
 WORKDIR /usr/local/src
 COPY environment.yml .
@@ -24,13 +33,13 @@ RUN conda env update -n base
 COPY . .
 
 # number of parallel make jobs
-ARG j=20
+ARG j=2
 RUN pip --no-cache-dir -v install .
 
 # run tests
 RUN bash tests/run_tests.sh
 
 # optimize layers
-FROM debian:bookworm-20230919-slim
+FROM debian:bookworm-slim
 COPY --from=builder /opt/conda /opt/conda
 ENV PATH=/opt/conda/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update && \
       wget
 
 # install miniconda3
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-Linux-x86_64.sh \
-    && /bin/bash Miniconda3-py310_23.11.0-1-Linux-x86_64.sh -b -p /opt/conda \
-    && rm Miniconda3-py310_23.11.0-1-Linux-x86_64.sh
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-1-Linux-$(uname -m).sh \
+    && /bin/bash Miniconda3-py310_23.11.0-1-Linux-$(uname -m).sh -b -p /opt/conda \
+    && rm Miniconda3-py310_23.11.0-1-Linux-$(uname -m).sh
 ENV PATH=/opt/conda/bin:$PATH
 
 # install cmake binary using conda for multi-arch support

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Note: QEMU emulated ppc64le build might take ~6 hours
 
 # Use conda to resolve dependencies cross-platform
-FROM continuumio/miniconda3:22.11.1 as builder
+FROM continuumio/miniconda3:23.5.2-0 as builder
 
 # install libpng to system for cross-architecture support
 # https://github.com/ANTsX/ANTs/issues/1069#issuecomment-681131938
@@ -24,13 +24,13 @@ RUN conda env update -n base
 COPY . .
 
 # number of parallel make jobs
-ARG j=2
+ARG j=20
 RUN pip --no-cache-dir -v install .
 
 # run tests
 RUN bash tests/run_tests.sh
 
 # optimize layers
-FROM debian:bullseye-20230109-slim
+FROM debian:bullseye-20230919-slim
 COPY --from=builder /opt/conda /opt/conda
 ENV PATH=/opt/conda/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ RUN pip --no-cache-dir -v install .
 RUN bash tests/run_tests.sh
 
 # optimize layers
-FROM debian:bullseye-20230919-slim
+FROM debian:bookworm-20230919-slim
 COPY --from=builder /opt/conda /opt/conda
 ENV PATH=/opt/conda/bin:$PATH

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import sys
 import time
-from distutils.version import LooseVersion
 from functools import cmp_to_key
 
 import setuptools
@@ -106,9 +105,7 @@ class CMakeBuild(build_ext):
                 + ", ".join(e.name for e in self.extensions)
             )
 
-        cmake_version = LooseVersion(
-            re.search(r"version\s*([\d.]+)", out.decode()).group(1)
-        )
+        cmake_version = re.search(r"version\s*([\d.]+)", out.decode()).group(1)
         if cmake_version < "3.10.0":
             raise RuntimeError("CMake >= 3.10.0 is required")
 


### PR DESCRIPTION
All tests passing and building successfully:
- wheels (`linux_aarch64` and `macos_arm64`)
- docker (`linux_aarch64` and `linux_amd64`) 

Wheels (and detailed logs) can be found here: https://cirrus-ci.com/build/5424545834729472

I haven't tested the `amd64` wheels for Windows/Linux/MacOS due to concurrency limits on Cirrus CI, but GitHub Actions should fill in the gap.