### PR TITLE
Refactor CI for PyPI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,7 +113,6 @@ macos_arm64_task:
     image: ghcr.io/cirruslabs/macos-sonoma-xcode:15.1
   env:
     matrix:
-      - CIBW_BUILD: cp38-macosx_arm64
       - CIBW_BUILD: cp39-macosx_arm64
       - CIBW_BUILD: cp310-macosx_arm64
       - CIBW_BUILD: cp311-macosx_arm64
@@ -125,7 +124,6 @@ macos_arm64_task:
     CIBW_BEFORE_TEST: |
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
-    CIBW_TEST_SKIP: cp38-macosx_*:arm64
     PATH: $HOME/mambaforge/bin/:${PATH}
     CONDA_HOME: $HOME/mambaforge
   conda_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,23 +3,31 @@ env:
   DOCKERHUB_ORG: noelmni
   DOCKERHUB_REPO: antspy
   DOCKER_USERNAME: ENCRYPTED[!09cc4caa9cb6dbf5af7f2630c1d74076abd1cff6bb103db2bae45d022f28404e040ee5db21f076f70decb59a294780ab!]
-  DOCKER_PASSWORD: ENCRYPTED[!3eccd194e0044101db2d7379d2d95f9255e3493c7ae72a6843ca83a6547ea271541271d77858a2ffd30f61ab68514a64!]
-  GITHUB_TOKEN: ENCRYPTED[!PLACEHOLDER_FOR_GITHUB_TOKEN!]
-  TWINE_USERNAME: ENCRYPTED[!PLACEHOLDER_FOR_TWINE_USERNAME!] # username for pypi
-  TWINE_PASSWORD: ENCRYPTED[!PLACEHOLDER_FOR_TWINE_PASSWORD!] # password for pypi
+  DOCKER_PASSWORD: ENCRYPTED[!4e8f945da70908366e7389ee7192c8c3f13d3f0411a75442bef1af794c2ce547e83b9b60044923c9775790b622da54f1!]
+  GITHUB_TOKEN: ENCRYPTED[!67d503db87885a2486161bdc51da6492e80c522c551c8d2c9b6f871af8adb354ca825c128a7b79f6755eb8b99610732a!]
+  TWINE_USERNAME: __token__ # username for pypi
+  TWINE_PASSWORD: ENCRYPTED[!40b9d18b454ec9c49f6b2df6afda3769644014f0c4612ac36db620c27fe58964ff81138c4e28e01b8a0001291e3eba1c!] # api token for pypi
   TAG_x86_64: ci-x86_64-tmp
   TAG_AARCH64: ci-aarch64-tmp
 
 
 build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   install_cibuildwheel_pipx_script:
+    - which python
+    - python -VV
+    - python -m pip install --upgrade build pip twine
     - python -m pip install cibuildwheel==2.16.2 jq pipx setuptools
     - python -m pipx ensurepath
+    - which pipx
   run_cibuildwheel_script:
-    - cibuildwheel
+    - pipx run cibuildwheel
+  wheels_artifacts:
+    path: "wheelhouse/*"
   make_sdist_script:
     - rm -rf dist # clear out your 'dist' folder 
     - pipx run build --sdist # make a source distribution
+  sdist_artifacts:
+    path: "dist/*.tar.gz"
   upload_releases_script: |
     #!/usr/bin/env bash
 
@@ -48,19 +56,15 @@ build_and_store_wheels: &BUILD_AND_STORE_WHEELS
   upload_pypi_script: |
     #!/usr/bin/env bash
 
-    if [[ "${CIRRUS_RELEASE}" == "" ]]; then
-        exit 0
-    fi
-
-    # deploy source distribution to PyPI using 'twine'
-    pipx run twine upload -r pypi dist/*
+    # if [[ "${CIRRUS_RELEASE}" == "" ]]; then
+    #     exit 0
+    # fi
 
     # deploy wheels to PyPI
-    pipx run twine upload -r pypi wheelhouse/*
-  sdist_artifacts:
-    path: "dist/*.tar.gz"
-  wheels_artifacts:
-    path: "wheelhouse/*"
+    pipx run twine upload --repository pypi wheelhouse/*
+
+    # deploy source distribution to PyPI
+    pipx run twine upload --repository pypi dist/*
 
 
 linux_aarch64_task:
@@ -78,7 +82,7 @@ linux_aarch64_task:
     CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
     CIBW_BEFORE_ALL_LINUX: >
       yum install -y gcc-c++ libpng-devel libpng &&
-      python -m pip install cmake ninja setuptools
+      python -m pip install cmake ninja
     CIBW_BEFORE_TEST: |
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
@@ -106,7 +110,7 @@ macos_arm64_task:
   name: build_macos_arm64_wheels
   # only_if: ${CIRRUS_BRANCH} == 'master' || ${CIRRUS_PR} != ''
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:15
+    image: ghcr.io/cirruslabs/macos-sonoma-xcode:15.1
   env:
     matrix:
       - CIBW_BUILD: cp38-macosx_arm64
@@ -117,7 +121,7 @@ macos_arm64_task:
     CIBW_ARCHS_MACOS: arm64
     CIBW_BEFORE_ALL_MACOS: >
       python -m ensurepip --upgrade &&
-      conda install cmake ninja libpng setuptools
+      mamba install cmake ninja libpng
     CIBW_BEFORE_TEST: |
       python -m pip install --find-links=wheelhouse/ -r requirements.txt
     CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
@@ -125,8 +129,8 @@ macos_arm64_task:
     PATH: $HOME/mambaforge/bin/:${PATH}
     CONDA_HOME: $HOME/mambaforge
   conda_script:
-    - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
-    - bash ~/mambaforge.sh -b -p ~/mambaforge
+    - curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-23.3.1-1-MacOSX-arm64.sh
+    - bash ~/mambaforge.sh -b -p ${CONDA_HOME}
   <<: *BUILD_AND_STORE_WHEELS
 
 

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,4 +1,4 @@
-name: ci-docker
+name: Build docker image [x86_64]
 on:
   push:
     branches:
@@ -10,32 +10,31 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Docker meta
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: antsx/antspy
-      -
-        name: Login to DockerHub
+
+      - name: Login to DockerHub
         if: ${{ github.repository == 'ANTsX/ANTsPy' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/wheels-macosx_arm64.yml
+++ b/.github/workflows/wheels-macosx_arm64.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - refactor_ci_pypi
   pull_request:
     branches:
     - master
@@ -127,6 +126,7 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
+    if: github.event_name == 'release'
     needs: [build_wheels]
     runs-on: ubuntu-latest
     permissions:
@@ -134,7 +134,6 @@ jobs:
     steps:
     # retrieve your distributions here
     - name: Download artifacts
-      # needs: [build_wheels, build_sdist]
       uses: actions/download-artifact@v4
       with:
         # unpacks all CIBW artifacts into dist/
@@ -144,7 +143,6 @@ jobs:
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      # if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') }}
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheels-macosx_arm64.yml
+++ b/.github/workflows/wheels-macosx_arm64.yml
@@ -1,0 +1,182 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - master
+    - refactor_ci_pypi
+  pull_request:
+    branches:
+    - master
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Build wheel for cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macOS on Apple M1 64-bit
+          - os: [self-hosted, macOS, ARM64]
+            python: '3.9'
+            cibw_python: 39
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: [self-hosted, macOS, ARM64]
+            python: '3.10'
+            cibw_python: 310
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: [self-hosted, macOS, ARM64]
+            python: '3.11'
+            cibw_python: 311
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: [self-hosted, macOS, ARM64]
+            python: '3.12'
+            cibw_python: 312
+            arch: arm64
+            platform_id: macosx_arm64
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install Python host for cibuildwheel
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: false
+          activate-environment: py${{ matrix.cibw_python }}
+          installer-url: https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-23.3.1-1-MacOSX-arm64.sh
+          allow-softlinks: true
+          show-channel-urls: true
+          use-only-tar-bz2: true
+          channels: conda-forge
+          channel-priority: true
+          init-shell: bash
+          cache-environment: true
+          cache-environment-key: environment-${{ steps.date.outputs.date }}
+          cache-downloads-key: downloads-${{ steps.date.outputs.date }}
+          post-cleanup: 'all'
+          use-mamba: true
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
+          conda config --remove channels defaults
+          # dependencies
+          python -m ensurepip --upgrade
+          mamba install cmake ninja libpng setuptools
+
+      - name: Install cibuildwheel and other build tools
+        shell: bash -l {0}
+        run: |
+          python -m pip install --upgrade build pip twine setuptools
+          python -m pip install cibuildwheel==2.16.2 jq pipx
+          python -m pipx ensurepath
+
+      - name: Get package name and version (Linux / Mac)
+        shell: bash -l {0}
+        if: ${{ ! startsWith(matrix.os, 'windows-') }}
+        run: |
+          echo PACKAGE_NAME=$( python setup.py --name ) >> $GITHUB_ENV
+          echo PACKAGE_VERSION=$( python setup.py --version ) >> $GITHUB_ENV
+
+      - name: Build and test wheels
+        shell: bash -l {0}
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_BUILD: cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
+          # Include latest Python beta
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          CIBW_ENVIRONMENT_MACOS: |
+            CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}
+          CIBW_BEFORE_TEST: |
+            python -m pip install --find-links=wheelhouse/ -r requirements.txt
+          CIBW_TEST_COMMAND: bash {project}/tests/run_tests.sh
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
+
+      - name: Store wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
+          path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
+
+      - name: Upload release asset
+        # Previously was using actions/upload-release-asset@v1 , but this had some
+        # errors with large files
+        uses: ncipollo/release-action@v1.11.1
+        if: ${{ github.event_name == 'release' }}
+        with:
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          artifacts: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+
+  pypi-publish:
+    name: Upload release to PyPI
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    # retrieve your distributions here
+    - name: Download artifacts
+      # needs: [build_wheels, build_sdist]
+      uses: actions/download-artifact@v4
+      with:
+        # unpacks all CIBW artifacts into dist/
+        pattern: antspyx*
+        path: dist
+        merge-multiple: true
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      # if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') }}
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verify-metadata: false
+        skip-existing: true
+        verbose: true
+
+
+  testpypi-publish:
+    name: Upload release to TestPyPI
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/ANTsPy_macos_arm64
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+    steps:
+    # retrieve your distributions here
+    - name: Download artifacts
+      # needs: [build_wheels, build_sdist]
+      uses: actions/download-artifact@v4
+      with:
+        # unpacks all CIBW artifacts into dist/
+        pattern: antspyx*
+        path: dist
+        merge-multiple: true
+
+    - name: Publish package to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository-url: https://test.pypi.org/legacy/
+        verbose: true

--- a/.github/workflows/wheels-macosx_arm64.yml
+++ b/.github/workflows/wheels-macosx_arm64.yml
@@ -151,32 +151,3 @@ jobs:
         verify-metadata: false
         skip-existing: true
         verbose: true
-
-
-  testpypi-publish:
-    name: Upload release to TestPyPI
-    needs: [build_wheels]
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/ANTsPy_macos_arm64
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-    steps:
-    # retrieve your distributions here
-    - name: Download artifacts
-      # needs: [build_wheels, build_sdist]
-      uses: actions/download-artifact@v4
-      with:
-        # unpacks all CIBW artifacts into dist/
-        pattern: antspyx*
-        path: dist
-        merge-multiple: true
-
-    - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository-url: https://test.pypi.org/legacy/
-        verbose: true

--- a/.github/workflows/wheels-macosx_arm64.yml
+++ b/.github/workflows/wheels-macosx_arm64.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build wheels [macosx_arm64]
 
 on:
   push:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -167,8 +167,10 @@ jobs:
             python -m pip install cmake ninja setuptools
           CIBW_ENVIRONMENT_MACOS: |
             CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}
+          # Increase pip debugging output
+          CIBW_BUILD_VERBOSITY: 3
         run: |
-          python -m cibuildwheel --output-dir wheelhouse/cp${{ matrix.cibw_python }}-${{matrix.platform_id }}
+          python -m cibuildwheel --output-dir wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           pipx run build --sdist # make a source distribution
 
       - name: Install and test (Linux / Mac)
@@ -180,7 +182,7 @@ jobs:
       - name: Install and test (Windows)
         if: startsWith(matrix.os, 'windows-')
         run: |
-          python -m pip install --find-links=.\wheelhouse\cp${{ matrix.cibw_python }}-${{matrix.platform_id }} antspyx
+          python -m pip install --find-links=.\wheelhouse\cp${{ matrix.cibw_python }}-${{ matrix.platform_id }} antspyx
           tests\run_tests.ps1
 
       - name: Upload wheel artifacts
@@ -190,7 +192,7 @@ jobs:
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
 
       - name: Upload sdist artifact # only needs to be uploaded once
-        if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') && (matrix.cibw_python == 'py312')}}
+        if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') && (matrix.cibw_python == '312')}}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build wheels [x86_64]
 
 on:
   push:
@@ -149,30 +149,27 @@ jobs:
           -Append
           echo "PACKAGE_VERSION=$( python setup.py --version )" | Out-File -FilePath $env:GITHUB_ENV `
           -Append
-      - name: Build wheels
+
+      - name: Build wheels and make a source distribution
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BUILD: cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
-
           # Include latest Python beta
           CIBW_PRERELEASE_PYTHONS: True
-
           CIBW_BEFORE_ALL_LINUX: |
             yum install -y gcc-c++ libpng-devel libpng
             python -m pip install cmake ninja setuptools
-
           CIBW_BEFORE_ALL_WINDOWS: |
             python -m pip install cmake ninja setuptools
-
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_BEFORE_ALL_MACOS: |
             python -m pip install cmake ninja setuptools
-
           CIBW_ENVIRONMENT_MACOS: |
             CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }}
-
-        run: python -m cibuildwheel --output-dir wheelhouse/cp${{ matrix.cibw_python }}-${{matrix.platform_id }}
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse/cp${{ matrix.cibw_python }}-${{matrix.platform_id }}
+          pipx run build --sdist # make a source distribution
 
       - name: Install and test (Linux / Mac)
         if: ${{ ! startsWith(matrix.os, 'windows-') }}
@@ -186,10 +183,18 @@ jobs:
           python -m pip install --find-links=.\wheelhouse\cp${{ matrix.cibw_python }}-${{matrix.platform_id }} antspyx
           tests\run_tests.ps1
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
+
+      - name: Upload sdist artifact # only needs to be uploaded once
+        if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') && (matrix.cibw_python == 'py312')}}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}
+          path: ./dist/*.tar.gz
 
       - name: Upload release asset
         # Previously was using actions/upload-release-asset@v1 , but this had some

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -150,7 +150,7 @@ jobs:
           echo "PACKAGE_VERSION=$( python setup.py --version )" | Out-File -FilePath $env:GITHUB_ENV `
           -Append
 
-      - name: Build wheels and make a source distribution
+      - name: Build wheels
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
@@ -171,6 +171,10 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
         run: |
           python -m cibuildwheel --output-dir wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
+
+      - name: Make a source distribution
+        if: ${{ (runner.os == 'Linux') && (matrix.cibw_python == '312')}}
+        run: |
           pipx run build --sdist # make a source distribution
 
       - name: Install and test (Linux / Mac)
@@ -192,7 +196,7 @@ jobs:
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
 
       - name: Upload sdist artifact # only needs to be uploaded once
-        if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') && (matrix.cibw_python == '312')}}
+        if: ${{ (runner.os == 'Linux') && (matrix.cibw_python == '312') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - refactor_ci_pypi
   pull_request:
     branches:
     - master
@@ -202,25 +203,29 @@ jobs:
           artifacts: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish prep
-        if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') }}
-        run: |
-          mywhl=`find ~/ -name "antspyx*.whl"`
-          extrawheeldir=`dirname $mywhl`
-          wheeldirx=`dirname $extrawheeldir`
-          wheeldir=`dirname $wheeldirx`
-          wheeldir=${wheeldir}/dist
-          mkdir -p $wheeldir
-          echo $wheeldir
-          mv $mywhl $wheeldir
-          rm -r -f $extrawheeldir $wheeldirx
-          
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') }}
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verify_metadata: false
-          skip_existing: true
-          verbose: true
+
+  pypi-publish:
+    name: Upload release to PyPI
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    # retrieve your distributions here
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        # unpacks all CIBW artifacts into dist/
+        pattern: antspyx*
+        path: dist
+        merge-multiple: true
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      # if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') }}
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        verify-metadata: false
+        skip-existing: true
+        verbose: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -186,7 +186,7 @@ jobs:
           python -m pip install --find-links=.\wheelhouse\cp${{ matrix.cibw_python }}-${{matrix.platform_id }} antspyx
           tests\run_tests.ps1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - refactor_ci_pypi
   pull_request:
     branches:
     - master
@@ -217,6 +216,7 @@ jobs:
 
   pypi-publish:
     name: Upload release to PyPI
+    if: github.event_name == 'release'
     needs: [build_wheels]
     runs-on: ubuntu-latest
     permissions:
@@ -233,7 +233,6 @@ jobs:
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      # if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') }}
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Wheels are built and pushed to PyPI successfully for all OSs and architectures: [1](https://github.com/ANTsX/ANTsPy/actions/runs/7637933416), [2](https://cirrus-ci.com/build/5215578089062400). As before, we're utilizing 2 build systems: Cirrus CI (`macos_arm64` and `linux_aarch64`) and GHA (`macos_x86_64`,  `linux_x86_64`, and `win_amd64`). While GHA supports building natively on Apple Silicon via `macos-latest-xlarge` runner, this feature is limited to Teams/Enterprise accounts AFAIK. Besides, Cirrus CI provides substantially lower free credits relative to GHA, so there will be instances where the CI/CD for `arm64` will fail to execute due to insufficient credits. Therefore, as a stopgap, I've also provisioned a self-hosted macOS VM based on [Cirrus's Tart virtualization](https://github.com/cirruslabs/tart) that can run on Apple Silicon via `wheels-macosx_arm64.yml`. For this last bit to work, a [self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository) needs to be initialized via GitHub while I donate CPU time on my M1 MacBook Air as and if the need arises.

Pushing to PyPI is confirmed working using multiple build systems, so if the `secrets.PYPI_API_TOKEN` repository secret is configured it should be seamless. For Cirrus CI, once access to ANTsX/ANTsPy has been granted at https://cirrus-ci.com/, the runner should automatically read the config from `.cirrus.yml`.

In terms of PyPI storage, I believe we're at the max 10GB for the project, so upgrade requests should be in order to support another version or two.

On a related note, if there's interest, I can test pushing the multi-arch image (`amd64`/ `arm64`) directly to [Docker Hub](https://hub.docker.com/r/antsx/antspy/) - build works already through Cirrus CI. The current workflow (`ci-docker.yml`) only supports `amd64`. An access token or access delegation would be needed to accomplish that.

Cheers!