### PR TITLE
ENH: ARM64 builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -93,17 +93,7 @@ jobs:
             arch: x86_64
             platform_id: macosx_x86_64
 
-          # macOS on Apple M1 64-bit
-          - os: macos-14
-            python: '3.8'
-            cibw_python: 38
-            arch: arm64
-            platform_id: macosx_arm64
-          - os: macos-14
-            python: '3.9'
-            cibw_python: 39
-            arch: arm64
-            platform_id: macosx_arm64
+          # macOS on Apple M1 64-bit, supported for Python 3.10 and later
           - os: macos-14
             python: '3.10'
             cibw_python: 310

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,53 +67,58 @@ jobs:
             platform_id: manylinux_x86_64
 
           # macOS on Intel 64-bit
-          - os: macos-latest
+          - os: macos-12
             python: '3.8'
             cibw_python: 38
             arch: x86_64
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             python: '3.9'
             cibw_python: 39
             arch: x86_64
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             python: '3.10'
             cibw_python: 310
             arch: x86_64
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             python: '3.11'
             cibw_python: 311
             arch: x86_64
             platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-12
             python: '3.12'
             cibw_python: 312
             arch: x86_64
             platform_id: macosx_x86_64
 
           # macOS on Apple M1 64-bit
-          # - os: macos-latest
-          #   python: '3.8'
-          #   cibw_python: 38
-          #   arch: arm64
-          #   platform_id: macosx_arm64
-          # - os: macos-latest
-          #   python: '3.9'
-          #   cibw_python: 39
-          #   arch: arm64
-          #   platform_id: macosx_arm64
-          # - os: macos-latest
-          #   python: '3.10'
-          #   cibw_python: 310
-          #   arch: arm64
-          #   platform_id: macosx_arm64
-          # - os: macos-latest
-          #   python: '3.11'
-          #   cibw_python: 311
-          #   arch: arm64
-          #   platform_id: macosx_arm64
+          - os: macos-14
+            python: '3.8'
+            cibw_python: 38
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: '3.9'
+            cibw_python: 39
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: '3.10'
+            cibw_python: 310
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: '3.11'
+            cibw_python: 311
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: '3.12'
+            cibw_python: 312
+            arch: arm64
+            platform_id: macosx_arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -216,7 +221,7 @@ jobs:
           echo $wheeldir
           mv $mywhl $wheeldir
           rm -r -f $extrawheeldir $wheeldirx
-          
+
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
         if: ${{ (github.event_name == 'push') && (runner.os == 'Linux') }}


### PR DESCRIPTION
Set Intel Mac OS builds to OS 12, because I expect 'macos-latest' will switch over to arm64 at some point 