### PR TITLE
fix issue with plotting negative-sum images

### DIFF
--- a/ants/viz/plot.py
+++ b/ants/viz/plot.py
@@ -228,7 +228,7 @@ def plot(
     if not isinstance(image, iio.ANTsImage):
         raise ValueError("image argument must be an ANTsImage")
 
-    if not image.sum() > 0:
+    if sum(sum(image != 0)) == 0:
         warnings.warn("Image must be non-zero. will not plot.")
         return
 


### PR DESCRIPTION
If an image has a sum less than zero, then `ants.plot` rejects it. This is due to code that incorrectly identifies whether an image is all-zero. 

This should work:

```python
import ants
img = ants.image_read(ants.get_ants_data('r16'))
img2 = (img - img.mean()) / img.std()
img2.plot()
```