### PR TITLE
change required slice_image args

### DIFF
--- a/ants/utils/slice_image.py
+++ b/ants/utils/slice_image.py
@@ -7,7 +7,7 @@ from ..core import ants_image as iio
 from .. import utils
 
 
-def slice_image(image, axis=None, idx=None, collapse_strategy=0):
+def slice_image(image, axis, idx, collapse_strategy=0):
     """
     Slice an image.
 


### PR DESCRIPTION
Both axis and idx are required for `ants.slice_image` - the function fails without them. This pr removes the optionality of those args from the function signature.