### PR TITLE
allow decrop_image to be chained

### DIFF
--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -611,7 +611,7 @@ if HAS_PY3:
     for k, v in utils.__dict__.items():
         if callable(v):
             args = inspect.getfullargspec(getattr(utils,k)).args
-            if (len(args) > 0) and (args[0] in {'img','image'}):
+            if (len(args) > 0) and (args[0] in {'img','image','cropped_image'}):
                 setattr(ANTsImage, k, partialmethod(v))
 
     for k, v in registration.__dict__.items():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,6 +230,9 @@ class TestModule_crop_image(unittest.TestCase):
         cropped = ants.crop_image(fi, mask, 1)
         cropped = ants.smooth_image(cropped, 1)
         decropped = ants.decrop_image(cropped, fi)
+        
+        # test chaining
+        decropped = cropped.decrop_image(fi)
 
         # image not float
         cropped = ants.crop_image(fi.clone("unsigned int"), mask, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,9 +230,6 @@ class TestModule_crop_image(unittest.TestCase):
         cropped = ants.crop_image(fi, mask, 1)
         cropped = ants.smooth_image(cropped, 1)
         decropped = ants.decrop_image(cropped, fi)
-        
-        # test chaining
-        decropped = cropped.decrop_image(fi)
 
         # image not float
         cropped = ants.crop_image(fi.clone("unsigned int"), mask, 1)


### PR DESCRIPTION
The `decrop_image` function was not able to be called in a chaining manner as all other image-related functions (including `crop_image`) can be. This PR fixes that without breaking any existing code. 

The function still works exactly the same, but can now be optionally called directly from an image like this:

```python
mni = ants.image_read(ants.get_ants_data('mni'))
mni_crop = mni.crop_image()
mni_decrop = mni_crop.decrop_image(mni) # this didnt work previously
# traditional way still works:
mni_decrop = ants.decrop_image(mni_crop, mni)
```

