### PR TITLE
antspy to v0.5.0 and bump ants + itk versions to latest commit hashes

### DIFF
--- a/scripts/clone_itk.sh
+++ b/scripts/clone_itk.sh
@@ -11,7 +11,7 @@ fi
 
 # cd ./src
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-itktag=f136bfe8bdb86c068ef1627ca2a5c02d5aa2fa24
+itktag=be79ceb0a9343c02dba310f5faee371941f6fa40 # 3-15-24
 # if ther is a directory but no git,
 # remove it
 if [[ -d itksource ]]; then

--- a/scripts/configure_ANTsPy.bat
+++ b/scripts/configure_ANTsPy.bat
@@ -18,7 +18,7 @@ COPY data\* %USERPROFILE%\.antspy
 
 :: clone ANTs and move all files into library directory
 SET antsgit=https://github.com/ANTsX/ANTs.git
-SET antstag=276cf0717945d3dd3c4298c607d9d6a788ba574e
+SET antstag=6c29d9d1d62f158ca324d5fc8786fffc469998e7
 echo "ANTS;%antstag%" REM UNKNOWN: {"type":"Redirect","op":{"text":">>","type":"dgreat"},"file":{"text":"./data/softwareVersions.csv","type":"Word"}}
 cd ants\lib
 echo "123"

--- a/scripts/configure_ANTsPy.sh
+++ b/scripts/configure_ANTsPy.sh
@@ -23,7 +23,7 @@ cp data/* ~/.antspy/
 # clone ANTs and move all files into library directory
 
 antsgit=https://github.com/ANTsX/ANTs.git
-antstag=dfd9e6664f2fc5f0dbd05c6c23d5e4895e82abee
+antstag=6c29d9d1d62f158ca324d5fc8786fffc469998e7 # 3-15-24
 echo "ANTS;${antstag}" >> ./data/softwareVersions.csv
 
 cd ants/lib # go to lib dir

--- a/scripts/configure_ANTsPy_windows.sh
+++ b/scripts/configure_ANTsPy_windows.sh
@@ -17,7 +17,7 @@ cp data/* ~/.antspy/
 # clone ANTs and move all files into library directory
 
 antsgit=https://github.com/ANTsX/ANTs.git
-antstag=35a76bc6b03a036ff69c5b95d6a2a0a0e601303c
+antstag=6c29d9d1d62f158ca324d5fc8786fffc469998e7 # 3-15-24
 echo "ANTS;${antstag}" >> ./data/softwareVersions.csv
 
 cd ants/lib # go to lib dir

--- a/scripts/configure_ITK.bat
+++ b/scripts/configure_ITK.bat
@@ -4,7 +4,7 @@
 SET CMAKE_BUILD_TYPE=Release
 
 SET itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-SET itktag=v5.3rc03
+SET itktag=be79ceb0a9343c02dba310f5faee371941f6fa40
 
 :: if there is a directory but no git, remove it
 if exist itksource\ (

--- a/scripts/configure_ITK.sh
+++ b/scripts/configure_ITK.sh
@@ -15,7 +15,7 @@ fi
 
 #cd ./src
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-itktag=ce57f309f4f4142b80367fd89a88f8dac9d6943a # update ITK tag 11/21/2022
+itktag=be79ceb0a9343c02dba310f5faee371941f6fa40 # 3-15-24
 # if there is a directory but no git, remove it
 if [[ -d itksource ]]; then
     if [[ ! -d itksource/.git ]]; then

--- a/scripts/configure_ITK_External_linux.sh
+++ b/scripts/configure_ITK_External_linux.sh
@@ -8,7 +8,7 @@ if [[ ! -d $itkdir ]] ; then
 fi
 cd $itkdir
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-itktag=ce57f309f4f4142b80367fd89a88f8dac9d6943a
+itktag=be79ceb0a9343c02dba310f5faee371941f6fa40 # 3-15-24
 if [[ ! -d ITK ]] ; then
   git clone $itkgit
 fi

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 setup_py_dir = os.path.dirname(os.path.realpath(__file__))
-version = "0.4.2"  # ANTsPy version
+version = "0.5.0"  # ANTsPy version
 
 if "--weekly" in sys.argv:
     sys.argv.remove("--weekly")
@@ -57,18 +57,6 @@ class BuildExtFirst(setuptools.command.install.install):
 
 class CMakeBuild(build_ext):
     def run(self):
-        ## Find or Configure VTK ##
-        # print('Configuring VTK')
-        # if os.getenv('VTK_DIR'):
-        #    print('Using Local VTK Installation at:\n %s' % os.getenv('VTK_DIR'))
-        # elif os.path.exists(os.path.join(setup_py_dir, 'vtkbuild')):
-        #    print('Using local VTK already built for this package')
-        #    os.environ['VTK_DIR'] = os.path.join(setup_py_dir, 'vtkbuild')
-        # else:
-        #    print('No local VTK installation found... Building VTK now...')
-        #    subprocess.check_call(['./scripts/configure_VTK.sh'], cwd=setup_py_dir)
-        #    os.environ['VTK_DIR'] = os.path.join(setup_py_dir, 'vtkbuild')
-
         ## Find or Configure ITK ##
         print("Configuring ITK")
         if os.getenv("ITK_DIR"):


### PR DESCRIPTION
Bumps antspy to v0.5.0 and use the latest ants and itk commit hashes for building. We'll see if it's this simple...

Eventual general release notes:

- improved testing 
- minor bug fixes
- minor documentation improvements
- upgrade to latest ANTs and ITK version
- removed deprecated code (VTK-related visualization)

Things to accomplish during v0.5.x
- rework docs and tutorials (to ants.dev)
- reduce build size
- refactor ants.plot function to be simpler
- speed up import time (by deferring imports?)