### PR TITLE
Use double precision by default in apply_transforms computations

### DIFF
--- a/ants/registration/apply_transforms.py
+++ b/ants/registration/apply_transforms.py
@@ -11,7 +11,7 @@ from .. import utils
 def apply_transforms(fixed, moving, transformlist,
                      interpolator='linear', imagetype=0,
                      whichtoinvert=None, compose=None,
-                     defaultvalue=0, singleprecision=True, verbose=False, **kwargs):
+                     defaultvalue=0, singleprecision=False, verbose=False, **kwargs):
     """
     Apply a transform list to map an image from one domain to another.
     In image registration, one computes mappings between (usually) pairs
@@ -68,9 +68,8 @@ def apply_transforms(fixed, moving, transformlist,
         Default voxel value for mappings outside the image domain.
 
     singleprecision : boolean
-        if True, use float32 for computations and output data storage type. This reduces
-        memory storage and computational time for large images, but may result in a loss
-        of precision. Set to False to use double precision.
+        if True, use float32 for computations. This is useful for reducing memory
+        usage for large datasets, at the cost of precision.
 
     verbose : boolean
         print command and run verbose application of transform.

--- a/tests/test_core_ants_transform.py
+++ b/tests/test_core_ants_transform.py
@@ -87,7 +87,7 @@ class TestClass_ANTsTransform(unittest.TestCase):
         img = ants.image_read(ants.get_ants_data("r16")).clone('float')
         tx = ants.new_ants_transform(dimension=2)
         tx.set_parameters((0.9,0,0,1.1,10,11))
-        img2 = tx.apply(data=img, reference=img, data_type='image')  
+        img2 = tx.apply(data=img, reference=img, data_type='image')
 
     def test_apply_to_point(self):
         tx = ants.new_ants_transform()
@@ -99,14 +99,14 @@ class TestClass_ANTsTransform(unittest.TestCase):
         tx = ants.new_ants_transform()
         params = tx.parameters
         tx.set_parameters(params*2)
-        pt2 = tx.apply_to_vector((1,2,3)) # should be (2,4,6)    
+        pt2 = tx.apply_to_vector((1,2,3)) # should be (2,4,6)
 
     def test_apply_to_image(self):
         for ptype in self.pixeltypes:
             img = ants.image_read(ants.get_ants_data("r16")).clone(ptype)
             tx = ants.new_ants_transform(dimension=2)
             tx.set_parameters((0.9,0,0,1.1,10,11))
-            img2 = tx.apply_to_image(img, img)   
+            img2 = tx.apply_to_image(img, img)
 
 
 class TestModule_ants_transform(unittest.TestCase):
@@ -154,7 +154,8 @@ class TestModule_ants_transform(unittest.TestCase):
         img = ants.image_read(ants.get_ants_data("r16")).clone('float')
         tx = ants.new_ants_transform(dimension=2)
         tx.set_parameters((0.9,0,0,1.1,10,11))
-        img2 = ants.apply_ants_transform(tx, data=img, reference=img, data_type='image')  
+        img2 = ants.apply_ants_transform(tx, data=img, reference=img, data_type='image')
+
 
     def test_apply_ants_transform_to_point(self):
         tx = ants.new_ants_transform()

--- a/tests/test_registation.py
+++ b/tests/test_registation.py
@@ -53,9 +53,9 @@ class TestModule_apply_transforms(unittest.TestCase):
         self.assertTrue(ants.ants_image.image_physical_space_consistency(fixed, mywarpedimage,
                                                                          0.0001, datatype = False))
 
-        # Call with double precision for transforms, but should still return input type
+        # Call with float precision for transforms, but should still return input type
         mywarpedimage2 = ants.apply_transforms(
-            fixed=fixed, moving=moving, transformlist=mytx["fwdtransforms"], singleprecision=False
+            fixed=fixed, moving=moving, transformlist=mytx["fwdtransforms"], singleprecision=True
         )
         self.assertEqual(mywarpedimage2.pixeltype, moving.pixeltype)
         self.assertAlmostEqual(mywarpedimage.sum(), mywarpedimage2.sum(), places=3)

--- a/tests/test_registation.py
+++ b/tests/test_registation.py
@@ -44,11 +44,21 @@ class TestModule_apply_transforms(unittest.TestCase):
         fixed = ants.image_read(ants.get_ants_data("r16"))
         moving = ants.image_read(ants.get_ants_data("r64"))
         fixed = ants.resample_image(fixed, (64, 64), 1, 0)
-        moving = ants.resample_image(moving, (64, 64), 1, 0)
+        moving = ants.resample_image(moving, (128, 128), 1, 0)
         mytx = ants.registration(fixed=fixed, moving=moving, type_of_transform="SyN")
         mywarpedimage = ants.apply_transforms(
             fixed=fixed, moving=moving, transformlist=mytx["fwdtransforms"]
         )
+        self.assertEqual(mywarpedimage.pixeltype, moving.pixeltype)
+        self.assertTrue(ants.ants_image.image_physical_space_consistency(fixed, mywarpedimage,
+                                                                         0.0001, datatype = False))
+
+        # Call with double precision for transforms, but should still return input type
+        mywarpedimage2 = ants.apply_transforms(
+            fixed=fixed, moving=moving, transformlist=mytx["fwdtransforms"], singleprecision=False
+        )
+        self.assertEqual(mywarpedimage2.pixeltype, moving.pixeltype)
+        self.assertAlmostEqual(mywarpedimage.sum(), mywarpedimage2.sum(), places=3)
 
         # bad interpolator
         with self.assertRaises(Exception):


### PR DESCRIPTION
Fixes #574 

I made an option to use single float precision, with default False. For long 4D time series, the memory requirements can be quite large, so it's good to be able to use float.