### PR TITLE
FIX: remove assumed pixeltype for image_read

### DIFF
--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -460,7 +460,7 @@ def image_clone(image, pixeltype=None):
     return image.clone(pixeltype)
 
 
-def image_read(filename, dimension=None, pixeltype="float", reorient=False):
+def image_read(filename, dimension=None, pixeltype=None, reorient=False):
     """
     Read an ANTsImage from file
 


### PR DESCRIPTION
Im rewriting the c++ wrapping (with great success so far) and i randomly stumbled upon this issue. Basically, whenever you read an image it always clones the image. This is a bit inefficient. I dont think there is any reason to assume images should always be float type, unless I'm wrong there? If users want float they can supply it.