### PR TITLE
ENH: Update coveralls version

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
 
       - name: Install package
@@ -24,4 +24,4 @@ jobs:
         run: tests/run_tests.sh -c
 
       - name: Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@v2.2.3


### PR DESCRIPTION
Bumping the version, hoping to avoid coverage errors.

On coveralls.io, docstrings are being interpreted as uncovered code. This seems to only be a problem on multi-line function definitions.

https://coveralls.io/builds/66464549/source?filename=home%2Frunner%2F.local%2Flib%2Fpython3.10%2Fsite-packages%2Fants%2Fsegmentation%2Fatropos.py

I don't see this issue on my local machine if I run the tests

