### PR TITLE
ENH: Use XML for coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,3 +25,5 @@ jobs:
 
       - name: Coveralls
         uses: coverallsapp/github-action@v2.2.3
+        with:
+          format: python

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -49,7 +49,7 @@ $PYCMD test_bugs.py $@
 
 if [[ $COVERAGE -eq 1 ]]; then
     coverage combine
-    coverage html
+    coverage xml
 fi
 
 


### PR DESCRIPTION
coveralls recommends xml if the output is not being interpreted correctly