### PR TITLE
FIX: remove plot_ortho return statement

### DIFF
--- a/ants/viz/plot_ortho.py
+++ b/ants/viz/plot_ortho.py
@@ -625,5 +625,4 @@ def plot_ortho(
 
     # turn warnings back to default
     warnings.simplefilter("default")
-    return { "image": imageReturn, "overlay": overlayReturn }
 


### PR DESCRIPTION
The `plot_ortho` function should not return anything. And this function gives an Unbound Local Error if there is no overlay supplied.