### PR TITLE
ENH: support resampling multi-channel images

### DIFF
--- a/ants/registration/resample_image.py
+++ b/ants/registration/resample_image.py
@@ -70,7 +70,7 @@ def resample_image(image, resample_params, use_voxels=False, interp_type=1):
             outimage = outimage.clone(image.pixeltype)
             new_images.append(outimage)
         outimage = utils.merge_channels(new_images)
-        raise outimage
+        return outimage
 
 
 def resample_image_to_target(image, target, interp_type='linear', imagetype=0, verbose=False, **kwargs):

--- a/ants/registration/resample_image.py
+++ b/ants/registration/resample_image.py
@@ -40,6 +40,9 @@ def resample_image(image, resample_params, use_voxels=False, interp_type=1):
     >>> fi = ants.image_read( ants.get_ants_data("r16"))
     >>> finn = ants.resample_image(fi,(50,60),True,0)
     >>> filin = ants.resample_image(fi,(1.5,1.5),False,1)
+    >>> img = ants.image_read( ants.get_ants_data("r16"))
+    >>> img = ants.merge_channels([img, img])
+    >>> outimg = ants.resample_image(img, (128,128), True)
     """
     if image.components == 1:
         inimage = image.clone('float')
@@ -53,7 +56,21 @@ def resample_image(image, resample_params, use_voxels=False, interp_type=1):
         outimage = outimage.clone(image.pixeltype)
         return outimage
     else:
-        raise ValueError('images with more than 1 component not currently supported')
+        images = utils.split_channels(image)
+        new_images = []
+        for image in images:
+            inimage = image.clone('float')
+            outimage = image.clone('float')
+            rsampar = 'x'.join([str(rp) for rp in resample_params])
+
+            args = [image.dimension, inimage, outimage, rsampar, int(use_voxels), interp_type]
+            processed_args = utils._int_antsProcessArguments(args)
+            libfn = utils.get_lib_fn('ResampleImage')
+            libfn(processed_args)
+            outimage = outimage.clone(image.pixeltype)
+            new_images.append(outimage)
+        outimage = utils.merge_channels(new_images)
+        raise outimage
 
 
 def resample_image_to_target(image, target, interp_type='linear', imagetype=0, verbose=False, **kwargs):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -295,6 +295,13 @@ class TestModule_resample_image(unittest.TestCase):
         fi = ants.image_read(ants.get_ants_data("r16"))
         finn = ants.resample_image(fi, (50, 60), True, 0)
         filin = ants.resample_image(fi, (1.5, 1.5), False, 1)
+    
+    def test_resample_channels(self):
+        img = ants.image_read( ants.get_ants_data("r16"))
+        img = ants.merge_channels([img, img])
+        outimg = ants.resample_image(img, (128,128), True)
+        self.assertEqual(outimg.shape, (128, 128))
+        self.assertEqual(outimg.components, 2)
 
     def test_resample_image_to_target_example(self):
         fi = ants.image_read(ants.get_ants_data("r16"))


### PR DESCRIPTION
This PR adds support for multi-channel images in `resample_image`. The docstring says it's supported and there has pretty much always been an exception raised for multi-channel, so I think I just never got around to implementing it.

This implementation is the simplest - it just splits the channels and resamples on each of them individually. I think the ants function `ResampleImage` supports vector images natively, so that may be preferred in the future.