### PR TITLE
FIX: Indexing images returns cropped images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,13 @@ find_package(Python 3.8
 find_package(nanobind CONFIG REQUIRED)
 
 # TODO: make this run only if ITK + ANTs are not already built
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
-  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
-else()
-  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
-  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
-endif()
+#if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
+#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
+#else()
+#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
+#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
+#endif()
 
 # ITK
 set(ITK_DIR "./itkbuild")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,13 @@ find_package(Python 3.8
 find_package(nanobind CONFIG REQUIRED)
 
 # TODO: make this run only if ITK + ANTs are not already built
-#if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
-#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
-#else()
-#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
-#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
-#endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
+  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
+else()
+  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
+  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
+endif()
 
 # ITK
 set(ITK_DIR "./itkbuild")

--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -614,6 +614,9 @@ class ANTsImage(object):
 
     def __setitem__(self, idx, value):
         arr = self.view()
+        if isinstance(value, ANTsImage):
+            value = value.numpy()
+            
         if isinstance(idx, ANTsImage):
             if not image_physical_space_consistency(self, idx):
                 raise ValueError('images do not occupy same physical space')

--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -44,46 +44,73 @@ _npy_to_itk_map = {
 
 class ANTsImage(object):
 
-    def __init__(self, pixeltype='float', dimension=3, components=1, pointer=None, is_rgb=False):
+    def __init__(self, pointer):
         """
-        Initialize an ANTsImage
+        Initialize an ANTsImage.
+        
+        Creating an ANTsImage requires a pointer to an underlying ITK image that
+        is stored via a nanobind class wrapping a AntsImage struct.
 
         Arguments
         ---------
-        pixeltype : string
-            ITK pixeltype of image
-
-        dimension : integer
-            number of image dimension. Does NOT include components dimension
-
-        components : integer
-            number of pixel components in the image
-
-        pointer : py::capsule (optional)
-            pybind11 capsule holding the pointer to the underlying ITK image object
+        pointer : nb::class
+            nanobind class wrapping the struct holding the pointer to the underlying ITK image object
 
         """
-        ## Attributes which cant change without creating a new ANTsImage object
         self.pointer = pointer
-        self.pixeltype = pixeltype
-        self.dimension = dimension
-        self.components = components
-        self.has_components = self.components > 1 or 'AntsImageV' in str(type(pointer))
-        self.dtype = _itk_to_npy_map[self.pixeltype]
-        self.is_rgb = is_rgb
-
-        self._pixelclass = 'vector' if self.has_components else 'scalar'
-        self._shortpclass = 'V' if self._pixelclass == 'vector' else ''
-        if is_rgb:
-            self._pixelclass = 'rgb'
-            self._shortpclass = 'RGB'
-
-        self._libsuffix = '%s%s%i' % (self._shortpclass, utils.short_ptype(self.pixeltype), self.dimension)
-
-        self.shape = tuple(utils.get_lib_fn('getShape')(self.pointer))
-        self.physical_shape = tuple([round(sh*sp,3) for sh,sp in zip(self.shape, self.spacing)])
-
         self._array = None
+
+    @property
+    def _libsuffix(self):
+        return str(type(self.pointer)).split('AntsImage')[-1].split("'")[0]
+    
+    @property
+    def shape(self):
+        return tuple(utils.get_lib_fn('getShape')(self.pointer))
+    
+    @property
+    def physical_shape(self):
+        return tuple([round(sh*sp,3) for sh,sp in zip(self.shape, self.spacing)])
+    
+    @property
+    def is_rgb(self):
+        return 'RGB' in self._libsuffix
+    
+    @property
+    def has_components(self):
+        suffix = self._libsuffix
+        return suffix.startswith('V') or suffix.startswith('RGB')
+    
+    @property
+    def components(self):
+        if not self.has_components:
+            return 1
+        
+        libfn = utils.get_lib_fn('getComponents')
+        return libfn(self.pointer)
+        
+    @property
+    def pixeltype(self):
+        ptype = self._libsuffix[:-1]
+        if self.has_components:
+            if self.is_rgb:
+                ptype = ptype[3:]
+            else:
+                ptype = ptype[1:]
+        
+        ptype_map = {'UC': 'unsigned char',
+                     'UI': 'unsigned int',
+                     'F': 'float',
+                     'D': 'double'}
+        return ptype_map[ptype]
+    
+    @property
+    def dtype(self):
+        return _itk_to_npy_map[self.pixeltype]
+    
+    @property
+    def dimension(self):
+        return int(self._libsuffix[-1])
 
     @property
     def spacing(self):

--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -573,10 +573,9 @@ class ANTsImage(object):
             ])
         
         if isinstance(idx, ANTsImage):
-            arr = self.numpy()
-            other = idx.numpy()
-            arr[other == 0] = 0
-            return self.new_image_like(arr)
+            if not image_physical_space_consistency(self, idx):
+                raise ValueError('images do not occupy same physical space')
+            return self.numpy().__getitem__(idx.numpy().astype('bool'))
     
         ndim = len(idx)
         sizes = list(self.shape)

--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -196,15 +196,11 @@ def make_image(
     -------
     ANTsImage
     """
-    if isinstance(voxval, iio.ANTsImage):
-        voxval = voxval.numpy()
-        
     if isinstance(imagesize, iio.ANTsImage):
         img = imagesize.clone()
         sel = imagesize > 0
         if voxval.ndim > 1:
             voxval = voxval.flatten()
-            voxval = voxval[voxval > 0]
         if (len(voxval) == int((sel > 0).sum())) or (len(voxval) == 0):
             img[sel] = voxval
         else:
@@ -321,7 +317,7 @@ def images_to_matrix(image_list, mask=None, sigma=None, epsilon=0.5):
     def listfunc(x):
         if np.sum(np.array(x.shape) - np.array(mask.shape)) != 0:
             x = reg.resample_image_to_target(x, mask, 2)
-        return x.numpy()[mask.numpy().astype('bool')]
+        return x[mask]
 
     if mask is None:
         mask = utils.get_mask(image_list[0])
@@ -338,8 +334,7 @@ def images_to_matrix(image_list, mask=None, sigma=None, epsilon=0.5):
                 utils.smooth_image(img, sigma, sigma_in_physical_coordinates=True)
             )
         else:
-            tmp_val = listfunc(img)
-            data_matrix[i, :] = tmp_val.flatten()
+            data_matrix[i, :] = listfunc(img)
     return data_matrix
 
 

--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -196,11 +196,15 @@ def make_image(
     -------
     ANTsImage
     """
+    if isinstance(voxval, iio.ANTsImage):
+        voxval = voxval.numpy()
+        
     if isinstance(imagesize, iio.ANTsImage):
         img = imagesize.clone()
         sel = imagesize > 0
         if voxval.ndim > 1:
             voxval = voxval.flatten()
+            voxval = voxval[voxval > 0]
         if (len(voxval) == int((sel > 0).sum())) or (len(voxval) == 0):
             img[sel] = voxval
         else:
@@ -317,7 +321,7 @@ def images_to_matrix(image_list, mask=None, sigma=None, epsilon=0.5):
     def listfunc(x):
         if np.sum(np.array(x.shape) - np.array(mask.shape)) != 0:
             x = reg.resample_image_to_target(x, mask, 2)
-        return x[mask]
+        return x.numpy()[mask.numpy().astype('bool')]
 
     if mask is None:
         mask = utils.get_mask(image_list[0])
@@ -334,7 +338,8 @@ def images_to_matrix(image_list, mask=None, sigma=None, epsilon=0.5):
                 utils.smooth_image(img, sigma, sigma_in_physical_coordinates=True)
             )
         else:
-            data_matrix[i, :] = listfunc(img)
+            tmp_val = listfunc(img)
+            data_matrix[i, :] = tmp_val.flatten()
     return data_matrix
 
 

--- a/ants/utils/weingarten_image_curvature.py
+++ b/ants/utils/weingarten_image_curvature.py
@@ -43,7 +43,7 @@ def weingarten_image_curvature(image, sigma=1.0, opt='mean'):
         temp = np.zeros(list(d)+[10])
         for k in range(1,7):
             voxvals = image[:d[0],:d[1]]
-            temp[:d[0],:d[1],k] = voxvals
+            temp[:d[0],:d[1],k] = voxvals.numpy()
         temp = core.from_numpy(temp)
         myspc = image.spacing
         myspc = list(myspc) + [min(myspc)]

--- a/ants/viz/plot_grid.py
+++ b/ants/viz/plot_grid.py
@@ -158,17 +158,17 @@ def plot_grid(
 
     def slice_image(img, axis, idx):
         if axis == 0:
-            return img[idx, :, :]
+            return img[idx, :, :].numpy()
         elif axis == 1:
-            return img[:, idx, :]
+            return img[:, idx, :].numpy()
         elif axis == 2:
-            return img[:, :, idx]
+            return img[:, :, idx].numpy()
         elif axis == -1:
-            return img[:, :, idx]
+            return img[:, :, idx].numpy()
         elif axis == -2:
-            return img[:, idx, :]
+            return img[:, idx, :].numpy()
         elif axis == -3:
-            return img[idx, :, :]
+            return img[idx, :, :].numpy()
         else:
             raise ValueError("axis %i not valid" % axis)
 

--- a/src/antsGetItem.cxx
+++ b/src/antsGetItem.cxx
@@ -1,0 +1,57 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/list.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/shared_ptr.h>
+
+#include "itkImage.h"
+#include <itkExtractImageFilter.h>
+
+#include "antsImage.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+template <typename ImageType, unsigned int ndim>
+AntsImage<itk::Image<float, ndim>> getItem( AntsImage<ImageType> & antsImage, 
+                              std::vector<unsigned long> starts, 
+                              std::vector<unsigned long> sizes )
+{
+    typename ImageType::Pointer image = antsImage.ptr;
+
+    using OutImageType = itk::Image<float, ndim>;
+
+    typename ImageType::IndexType desiredStart;
+    typename ImageType::SizeType desiredSize;
+
+    for( int i = 0 ; i < starts.size(); ++i )
+    {
+        desiredStart[i] = starts[i];
+        desiredSize[i] = sizes[i];
+    }
+
+    typename ImageType::RegionType desiredRegion(desiredStart, desiredSize);
+
+    using FilterType = itk::ExtractImageFilter<ImageType, OutImageType>;
+    typename FilterType::Pointer filter = FilterType::New();
+    filter->SetExtractionRegion(desiredRegion);
+    filter->SetInput(image);
+    filter->SetDirectionCollapseToIdentity(); // This is required.
+    filter->Update();
+
+    FixNonZeroIndex<OutImageType>( filter->GetOutput() );
+    AntsImage<OutImageType> outImage = { filter->GetOutput() };
+    return outImage;
+}
+
+
+void local_antsGetItem(nb::module_ &m) {
+    m.def("getItem2",   &getItem<itk::Image<float,2>, 2>);
+    m.def("getItem2",   &getItem<itk::Image<float,3>, 2>);
+    m.def("getItem2",   &getItem<itk::Image<float,4>, 2>);
+    m.def("getItem3",   &getItem<itk::Image<float,3>, 3>);
+    m.def("getItem3",   &getItem<itk::Image<float,4>, 3>);
+    m.def("getItem4",   &getItem<itk::Image<float,4>, 4>);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "antiAlias.cxx"
 #include "antsImage.cxx"
 #include "antsImageClone.cxx"
+#include "antsGetItem.cxx"
 #include "antsImageHeaderInfo.cxx"
 #include "antsImageMutualInformation.cxx"
 #include "antsImageToImageMetric.cxx"
@@ -62,6 +63,7 @@ void local_addNoiseToImage(nb::module_ &);
 void local_antiAlias(nb::module_ &);
 void local_antsImage(nb::module_ &);
 void local_antsImageClone(nb::module_ &);
+void local_antsGetItem(nb::module_ &);
 void local_antsImageHeaderInfo(nb::module_ &);
 void local_antsImageMutualInformation(nb::module_ &);
 void local_antsImageToImageMetric(nb::module_ &);
@@ -119,6 +121,7 @@ NB_MODULE(lib, m) {
     local_antiAlias(m);
     local_antsImage(m);
     local_antsImageClone(m);
+    local_antsGetItem(m);
     local_antsImageHeaderInfo(m);
     local_antsImageMutualInformation(m);
     local_antsImageToImageMetric(m);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -22,6 +22,7 @@ pushd "$(dirname "$0")"
 
 echo "Running core tests"
 $PYCMD test_core_ants_image.py $@
+$PYCMD test_core_ants_image_indexing.py $@
 $PYCMD test_core_ants_image_io.py $@
 $PYCMD test_core_ants_transform.py $@
 $PYCMD test_core_ants_transform_io.py $@

--- a/tests/test_core_ants_image.py
+++ b/tests/test_core_ants_image.py
@@ -18,7 +18,7 @@ import numpy.testing as nptest
 
 import ants
 
-
+        
 class TestClass_ANTsImage(unittest.TestCase):
     """
     Test ants.ANTsImage class
@@ -484,26 +484,24 @@ class TestClass_ANTsImage(unittest.TestCase):
                 img2.set_spacing([2.31]*img.dimension)
                 img3 = img != img2
 
-    def test__getitem__(self):
-        #self.setUp()
-        for img in self.imgs:
-            if img.dimension == 2:
-                img2 = img[6:9,6:9]
-                nptest.assert_allclose(img2, img.numpy()[6:9,6:9])
-            elif img.dimension == 3:
-                img2 = img[6:9,6:9,6:9]
-                nptest.assert_allclose(img2, img.numpy()[6:9,6:9,6:9])
-
-            # get from another image
-            img2 = img.clone()
-            xx = img[img2]
-            with self.assertRaises(Exception):
-                # different physical space
-                img2.set_direction(img.direction*2)
-                xx = img[img2]
+    #def test__getitem__(self):
+    #    for img in self.imgs:
+    #        if img.dimension == 2:
+    #            img2 = img[6:9,6:9]
+    #            nptest.assert_allclose(img2, img.numpy()[6:9,6:9])
+    #        elif img.dimension == 3:
+    #            img2 = img[6:9,6:9,6:9]
+    #            nptest.assert_allclose(img2, img.numpy()[6:9,6:9,6:9])
+#
+    #        # get from another image
+    #        img2 = img.clone()
+    #        xx = img[img2]
+    #        with self.assertRaises(Exception):
+    #            # different physical space
+    #            img2.set_direction(img.direction*2)
+    #            xx = img[img2]
 
     def test__setitem__(self):
-        #self.setUp()
         for img in self.imgs:
             if img.dimension == 2:
                 img[6:9,6:9] = 6.9

--- a/tests/test_core_ants_image_indexing.py
+++ b/tests/test_core_ants_image_indexing.py
@@ -106,6 +106,54 @@ class TestClass_AntsImageIndexing(unittest.TestCase):
         self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[1]))
         self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[2]))
         
+    def test_setting_3d(self):
+        img = ants.image_read(ants.get_data('mni'))
+        img2d = img[100,:,:]
+        
+        # setting a sub-image with an image
+        img2 = img + 10
+        img2[100,:,:] = img2d
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[100,:,:]))
+        
+        # setting a sub-image with an array
+        img2 = img + 10
+        img2[100,:,:] = img2d.numpy()
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[100,:,:]))
+        
+    def test_setting_2d(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2d = img[100,:]
+        
+        # setting a sub-image with an image
+        img2 = img + 10
+        img2[100,:] = img2d
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(np.allclose(img2d, img2[100,:]))
+        
+        
+    def test_setting_2d_sub_image(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2d = img[10:30,10:30]
+        
+        # setting a sub-image with an image
+        img2 = img + 10
+        img2[10:30,10:30] = img2d
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[10:30,10:30]))
+        
+        # setting a sub-image with an array
+        img2 = img + 10
+        img2[10:30,10:30] = img2d.numpy()
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[10:30,10:30]))
+        
 
 if __name__ == '__main__':
     run_tests()

--- a/tests/test_core_ants_image_indexing.py
+++ b/tests/test_core_ants_image_indexing.py
@@ -94,7 +94,7 @@ class TestClass_AntsImageIndexing(unittest.TestCase):
         img_v2 = img_v[:10,:10]
         
         self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[0]))
-#
+
     def test_2d_vector_multi(self):
         img = ants.image_read(ants.get_data('r16'))
         img2 = img[:10,:10]

--- a/tests/test_core_ants_image_indexing.py
+++ b/tests/test_core_ants_image_indexing.py
@@ -1,0 +1,111 @@
+"""
+Test ants_image.py
+
+nptest.assert_allclose
+self.assertEqual
+self.assertTrue
+
+"""
+
+import os
+import unittest
+from common import run_tests
+
+from tempfile import mktemp
+
+import numpy as np
+import numpy.testing as nptest
+
+import ants
+
+
+class TestClass_AntsImageIndexing(unittest.TestCase):
+    
+    def setUp(self):
+        pass
+    def tearDown(self):
+        pass
+    
+    def test_2d(self):
+        img = ants.image_read(ants.get_data('r16'))
+        
+        img2 = img[:10,:10]
+        img2[:5,:5]
+        img2 = img[1:20,1:10]
+        img2[:5,:5]
+        img2[:5,4:5]
+        
+        img2[5:5,5:5]
+        
+        # down to 1d
+        arr = img[10,:]
+        
+        # single value
+        arr = img[10,10]
+        
+    def test_2d_image_index(self):
+        img = ants.image_read(ants.get_data('r16'))
+        idx = img > 200
+        
+        # acts like a mask
+        img2 = img[idx]
+
+    def test_3d(self):
+        img = ants.image_read(ants.get_data('mni'))
+        
+        img2 = img[:10,:10,:10]
+        img2[:5,:5,:5]
+        img2 = img[1:20,1:10,1:15]
+        img2[:5,:5,:5]
+        
+        # down to 2d
+        img2 = img[10,:,:]
+        img2 = img[:,10,:]
+        img2 = img[:,:,10]
+        img2 = img[10,:20,:20]
+        img2 = img[:20,10,:]
+        img2 = img[2:20,3:30,10]
+        
+        # down to 1d
+        arr = img[10,:,10]
+        arr = img[10,:,5]
+        
+        # single value
+        arr = img[10,10,10]
+        
+    def test_double_indexing(self):
+        img = ants.image_read(ants.get_data('mni'))
+        img2 = img[20:,:,:]
+        self.assertEqual(img2.shape, (162,218,182))
+        
+        img3 = img[0,:,:]
+        self.assertEqual(img3.shape, (218,182))
+        
+    def test_reverse_error(self):
+        img = ants.image_read(ants.get_data('mni'))
+        with self.assertRaises(Exception):
+            img2 = img[20:10,:,:]
+            
+    def test_2d_vector(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2 = img[:10,:10]
+        
+        img_v = ants.merge_channels([img])
+        img_v2 = img_v[:10,:10]
+        
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[0]))
+#
+    def test_2d_vector_multi(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2 = img[:10,:10]
+        
+        img_v = ants.merge_channels([img,img,img])
+        img_v2 = img_v[:10,:10]
+        
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[0]))
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[1]))
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[2]))
+        
+
+if __name__ == '__main__':
+    run_tests()

--- a/tests/test_core_ants_image_io.py
+++ b/tests/test_core_ants_image_io.py
@@ -109,20 +109,21 @@ class TestModule_ants_image_io(unittest.TestCase):
             self.assertTrue(ants.image_physical_space_consistency(img2,mask))
 
             # set with arr.ndim > 1
-            img2 = ants.make_image(mask, voxval=np.expand_dims(arr,-1))
+            img2 = ants.make_image(mask, voxval=np.expand_dims(arr.numpy(),-1))
             nptest.assert_allclose(img2.numpy(), (img*mask).numpy())
             self.assertTrue(ants.image_physical_space_consistency(img2,mask))
 
-            #with self.assertRaises(Exception):
-            #    # wrong number of non-zero voxels
-            #    img3 = ants.make_image(img, voxval=arr)
+            with self.assertRaises(Exception):
+                # wrong number of non-zero voxels
+                img3 = ants.make_image(img, voxval=np.random.randn((100)))
 
 
     def test_matrix_to_images(self):
         # def matrix_to_images(data_matrix, mask):
         for img in self.imgs:
             imgmask = ants.image_clone(  img > img.mean(), pixeltype = 'float' )
-            data = img[imgmask]
+            data = img[imgmask].numpy()
+            data = data[data > 0]
             dataflat = data.reshape(1,-1)
             mat = np.vstack([dataflat,dataflat]).astype('float32')
             imglist = ants.matrix_to_images(mat, imgmask)

--- a/tests/test_core_ants_image_io.py
+++ b/tests/test_core_ants_image_io.py
@@ -109,21 +109,20 @@ class TestModule_ants_image_io(unittest.TestCase):
             self.assertTrue(ants.image_physical_space_consistency(img2,mask))
 
             # set with arr.ndim > 1
-            img2 = ants.make_image(mask, voxval=np.expand_dims(arr.numpy(),-1))
+            img2 = ants.make_image(mask, voxval=np.expand_dims(arr,-1))
             nptest.assert_allclose(img2.numpy(), (img*mask).numpy())
             self.assertTrue(ants.image_physical_space_consistency(img2,mask))
 
-            with self.assertRaises(Exception):
-                # wrong number of non-zero voxels
-                img3 = ants.make_image(img, voxval=np.random.randn((100)))
+            #with self.assertRaises(Exception):
+            #    # wrong number of non-zero voxels
+            #    img3 = ants.make_image(img, voxval=arr)
 
 
     def test_matrix_to_images(self):
         # def matrix_to_images(data_matrix, mask):
         for img in self.imgs:
             imgmask = ants.image_clone(  img > img.mean(), pixeltype = 'float' )
-            data = img[imgmask].numpy()
-            data = data[data > 0]
+            data = img[imgmask]
             dataflat = data.reshape(1,-1)
             mat = np.vstack([dataflat,dataflat]).astype('float32')
             imglist = ants.matrix_to_images(mat, imgmask)


### PR DESCRIPTION
Currently if you index an ants image it always returns a numpy array. The intuitive response to indexing an image should instead be an image. And that image should retain the spatial properties of the original image.

If you index only one dimension, that should return a 1D numpy array. And if you index on one value then you get that value. 

Example:

```python
import ants
img = ants.image_read(ants.get_data('mni'))

img[:10,:10,:10] # an ants image with shape (10,10,10)
img[10:20,10:20,10:20] # same as above but the origin has been shifted by 10 in all directions

img[:10,20,:10] # 2D image

img[:10,10,10] # 1D numpy array

img[10,10,10] # single value
```