### PR TITLE
ENH: initialize ANTsImage with pointer only

### DIFF
--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -3,6 +3,7 @@ Image IO
 """
 
 __all__ = [
+    'from_pointer',
     "image_header_info",
     "image_clone",
     "image_read",
@@ -66,6 +67,9 @@ for itype in {"scalar", "vector", "rgb", "rgba", "symmetric_second_rank_tensor"}
             _image_read_dict[itype][p][d] = "imageRead%s%s%i" % (ita, pa, d)
 
 
+def from_pointer(pointer):
+    return iio.ANTsImage(pointer)
+    
 def from_numpy(
     data, origin=None, spacing=None, direction=None, has_components=False, is_rgb=False
 ):
@@ -128,9 +132,7 @@ def _from_numpy(
 
     if not has_components:
         itk_image = libfn(data, data.shape[::-1])
-        ants_image = iio.ANTsImage(
-            pixeltype=ptype, dimension=ndim, components=1, pointer=itk_image
-        )
+        ants_image = from_pointer(itk_image)
         ants_image.set_origin(origin)
         ants_image.set_spacing(spacing)
         ants_image.set_direction(direction)
@@ -141,9 +143,7 @@ def _from_numpy(
         ants_images = []
         for i in range(len(arrays)):
             tmp_ptr = libfn(arrays[i], data_shape[::-1])
-            tmp_img = iio.ANTsImage(
-                pixeltype=ptype, dimension=ndim, components=1, pointer=tmp_ptr
-            )
+            tmp_img = from_pointer(tmp_ptr)
             tmp_img.set_origin(origin)
             tmp_img.set_spacing(spacing)
             tmp_img.set_direction(direction)
@@ -547,13 +547,7 @@ def image_read(filename, dimension=None, pixeltype="float", reorient=False):
         libfn = utils.get_lib_fn(_image_read_dict[pclass][ptype][ndim])
         itk_pointer = libfn(filename)
 
-        ants_image = iio.ANTsImage(
-            pixeltype=ptype,
-            dimension=ndim,
-            components=ncomp,
-            pointer=itk_pointer,
-            is_rgb=is_rgb,
-        )
+        ants_image = from_pointer(itk_pointer)
 
         if pixeltype is not None:
             ants_image = ants_image.clone(pixeltype)

--- a/ants/core/ants_transform.py
+++ b/ants/core/ants_transform.py
@@ -16,7 +16,7 @@ __all__ = ['ANTsTransform',
            'transform_index_to_physical_point',
            'transform_physical_point_to_index']
 
-from . import ants_image as iio
+from . import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -188,10 +188,7 @@ class ANTsTransform(object):
         reference = reference.clone(image.pixeltype)
 
         img_ptr = tform_fn(self.pointer, image.pointer, reference.pointer, interpolation)
-        return iio.ANTsImage(pixeltype=image.pixeltype,
-                            dimension=image.dimension,
-                            components=image.components,
-                            pointer=img_ptr)
+        return iio2.from_pointer(img_ptr)
 
     def __repr__(self):
         s = "ANTsTransform\n" +\

--- a/ants/core/ants_transform_io.py
+++ b/ants/core/ants_transform_io.py
@@ -10,7 +10,7 @@ __all__ = [
 import os
 import numpy as np
 
-from . import ants_image as iio
+from . import ants_image as iio, ants_image_io as iio2
 from . import ants_transform as tio
 from .. import utils
 
@@ -297,10 +297,7 @@ def transform_to_displacement_field(xfrm, ref):
         raise ValueError("Transform must be of DisplacementFieldTransform type")
     libfn = utils.get_lib_fn("antsTransformToDisplacementField")
     field_ptr = libfn(xfrm.pointer, ref.pointer)
-    return iio.ANTsImage( pixeltype=xfrm.precision,
-                          dimension=xfrm.dimension,
-                          components=xfrm.dimension,
-                          pointer=field_ptr)
+    return iio2.from_pointer(field_ptr)
 
 def read_transform(filename, precision="float"):
     """

--- a/ants/registration/reorient_image.py
+++ b/ants/registration/reorient_image.py
@@ -11,7 +11,7 @@ from tempfile import mktemp
 
 from . import apply_transforms
 from .. import utils
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 
 
 _possible_orientations = ['RIP','LIP',  'RSP',  'LSP',  'RIA',  'LIA',
@@ -72,8 +72,7 @@ def reorient_image2(image, orientation='RAS'):
      libfn = utils.get_lib_fn('reorientImage2')
      itkimage = libfn(image.pointer, orientation)
 
-     new_img = iio.ANTsImage(pixeltype='float', dimension=ndim,
-                          components=image.components, pointer=itkimage)#.clone(inpixeltype)
+     new_img = iio2.from_pointer(itkimage)
      if inpixeltype != 'float':
          new_img = new_img.clone(inpixeltype)
      return new_img

--- a/ants/segmentation/anti_alias.py
+++ b/ants/segmentation/anti_alias.py
@@ -40,5 +40,4 @@ def anti_alias(image):
 
     libfn = utils.get_lib_fn('antiAlias%s' % image._libsuffix)
     new_ptr = libfn(image.pointer)
-    return iio.ANTsImage(pixeltype='float', dimension=image.dimension, 
-                         components=image.components, pointer=new_ptr)
+    return iio2.from_pointer(new_ptr)

--- a/ants/utils/add_noise_to_image.py
+++ b/ants/utils/add_noise_to_image.py
@@ -1,7 +1,7 @@
 __all__ = ["add_noise_to_image"]
 
 from .. import utils
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 
 def add_noise_to_image(image,
                        noise_model,
@@ -47,9 +47,7 @@ def add_noise_to_image(image,
 
         libfn = utils.get_lib_fn("additiveGaussianNoise")
         noise = libfn(image.pointer, noise_parameters[0], noise_parameters[1])
-        output_image = iio.ANTsImage(pixeltype='float', 
-            dimension=image_dimension, components=1,
-            pointer=noise).clone('float')
+        output_image = iio2.from_pointer(noise).clone('float')
         return output_image
     elif noise_model == 'saltandpepper':
         if len(noise_parameters) != 3:
@@ -57,9 +55,7 @@ def add_noise_to_image(image,
 
         libfn = utils.get_lib_fn("saltAndPepperNoise")
         noise = libfn(image.pointer, noise_parameters[0], noise_parameters[1], noise_parameters[2])
-        output_image = iio.ANTsImage(pixeltype='float', 
-            dimension=image_dimension, components=1,
-            pointer=noise).clone('float')
+        output_image = iio2.from_pointer(noise).clone('float')
         return output_image
     elif noise_model == 'shot':
         if not isinstance(noise_parameters, (int, float)):
@@ -67,9 +63,7 @@ def add_noise_to_image(image,
 
         libfn = utils.get_lib_fn("shotNoise")
         noise = libfn(image.pointer, noise_parameters)
-        output_image = iio.ANTsImage(pixeltype='float', 
-            dimension=image_dimension, components=1,
-            pointer=noise).clone('float')
+        output_image = iio2.from_pointer(noise).clone('float')
         return output_image
     elif noise_model == 'speckle':
         if not isinstance(noise_parameters, (int, float)):
@@ -77,9 +71,7 @@ def add_noise_to_image(image,
 
         libfn = utils.get_lib_fn("speckleNoise")
         noise = libfn(image.pointer, noise_parameters)
-        output_image = iio.ANTsImage(pixeltype='float', 
-            dimension=image_dimension, components=1,
-            pointer=noise).clone('float')
+        output_image = iio2.from_pointer(noise).clone('float')
         return output_image
     else:
         raise ValueError("Unknown noise model.")    

--- a/ants/utils/channels.py
+++ b/ants/utils/channels.py
@@ -4,7 +4,7 @@
 __all__ = ['merge_channels',
            'split_channels']
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -45,10 +45,7 @@ def merge_channels(image_list):
     libfn = utils.get_lib_fn('mergeChannels')
     image_ptr = libfn([image.pointer for image in image_list])
     
-    return iio.ANTsImage(pixeltype=inpixeltype,
-                         dimension=dimension,
-                         components=components,
-                         pointer=image_ptr)
+    return iio2.from_pointer(image_ptr)
 
 
 def split_channels(image):
@@ -82,8 +79,7 @@ def split_channels(image):
 
     libfn = utils.get_lib_fn('splitChannels')
     itkimages = libfn(image.pointer)
-    antsimages = [iio.ANTsImage(pixeltype=inpixeltype, dimension=dimension, 
-                              components=components, pointer=itkimage) for itkimage in itkimages]
+    antsimages = [iio2.from_pointer(itkimage) for itkimage in itkimages]
     return antsimages
 
 

--- a/ants/utils/compose_displacement_fields.py
+++ b/ants/utils/compose_displacement_fields.py
@@ -1,7 +1,7 @@
 
 __all__ = ['compose_displacement_fields']
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -27,8 +27,7 @@ def compose_displacement_fields(displacement_field,
     libfn = utils.get_lib_fn('composeDisplacementFieldsD%i' % displacement_field.dimension)
     comp_field = libfn(displacement_field.pointer, warping_field.pointer)
 
-    new_image = iio.ANTsImage(pixeltype='float', dimension=displacement_field.dimension, 
-                         components=displacement_field.dimension, pointer=comp_field).clone('float')
+    new_image = iio2.from_pointer(comp_field).clone('float')
     return new_image
 
 

--- a/ants/utils/crop_image.py
+++ b/ants/utils/crop_image.py
@@ -7,7 +7,7 @@ __all__ = ['crop_image',
 
 
 from .get_mask import get_mask
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -52,8 +52,7 @@ def crop_image(image, label_image=None, label=1):
 
     libfn = utils.get_lib_fn('cropImage')
     itkimage = libfn(image.pointer, label_image.pointer, label, 0, [], [])
-    return iio.ANTsImage(pixeltype='float', dimension=ndim, 
-                        components=image.components, pointer=itkimage).clone(inpixeltype)
+    return iio2.from_pointer(itkimage).clone(inpixeltype)
 
 
 def crop_indices(image, lowerind, upperind):
@@ -98,8 +97,7 @@ def crop_indices(image, lowerind, upperind):
 
     libfn = utils.get_lib_fn('cropImage')
     itkimage = libfn(image.pointer, image.pointer, 1, 2, lowerind, upperind)
-    ants_image = iio.ANTsImage(pixeltype='float', dimension=image.dimension,
-                        components=image.components, pointer=itkimage)
+    ants_image = iio2.from_pointer(itkimage)
     if inpixeltype != 'float':
         ants_image = ants_image.clone(inpixeltype)
     return ants_image
@@ -141,8 +139,7 @@ def decrop_image(cropped_image, full_image):
     
     libfn = utils.get_lib_fn('cropImage')
     itkimage = libfn(cropped_image.pointer, full_image.pointer, 1, 1, [], [])
-    ants_image = iio.ANTsImage(pixeltype='float', dimension=cropped_image.dimension,
-                        components=cropped_image.components, pointer=itkimage)
+    ants_image = iio2.from_pointer(itkimage)
     if inpixeltype != 'float':
         ants_image = ants_image.clone(inpixeltype)
 

--- a/ants/utils/fit_bspline_displacement_field.py
+++ b/ants/utils/fit_bspline_displacement_field.py
@@ -2,7 +2,7 @@ __all__ = ["fit_bspline_displacement_field"]
 
 import numpy as np
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import core
 from .. import utils
 
@@ -198,8 +198,6 @@ def fit_bspline_displacement_field(displacement_field=None,
                               enforce_stationary_boundary, estimate_inverse, rasterize_points)
 
 
-    bspline_displacement_field = iio.ANTsImage(pixeltype='float',
-        dimension=dimensionality, components=dimensionality,
-        pointer=bspline_field).clone('float')
+    bspline_displacement_field = iio2.from_pointer(bspline_field).clone('float')
     return bspline_displacement_field
 

--- a/ants/utils/fit_bspline_object_to_scattered_data.py
+++ b/ants/utils/fit_bspline_object_to_scattered_data.py
@@ -2,7 +2,7 @@ __all__ = ["fit_bspline_object_to_scattered_data"]
 
 import numpy as np
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -183,8 +183,6 @@ def fit_bspline_object_to_scattered_data(scattered_data,
     if parametric_dimension == 1:
         return np.array(bspline_object)
     else:
-        bspline_image = iio.ANTsImage(pixeltype='float',
-          dimension=parametric_dimension, components=data_dimension,
-          pointer=bspline_object).clone('float')
+        bspline_image = iio2.from_pointer(bspline_object).clone('float')
         return bspline_image
 

--- a/ants/utils/fit_thin_plate_spline_displacement_field.py
+++ b/ants/utils/fit_thin_plate_spline_displacement_field.py
@@ -2,7 +2,7 @@ __all__ = ["fit_thin_plate_spline_displacement_field"]
 
 import numpy as np
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import core
 from .. import utils
 
@@ -101,8 +101,6 @@ def fit_thin_plate_spline_displacement_field(displacement_origins=None,
     libfn = utils.get_lib_fn("fitThinPlateSplineDisplacementFieldToScatteredDataD%i" % (dimensionality))
     tps_field = libfn(displacement_origins, displacements, origin, spacing, size, direction)
 
-    tps_displacement_field = iio.ANTsImage(pixeltype='float',
-        dimension=dimensionality, components=dimensionality,
-        pointer=tps_field).clone('float')
+    tps_displacement_field = iio2.from_pointer(tps_field).clone('float')
     return tps_displacement_field
 

--- a/ants/utils/histogram_match_image.py
+++ b/ants/utils/histogram_match_image.py
@@ -50,8 +50,7 @@ def histogram_match_image(source_image, reference_image, number_of_histogram_bin
     libfn = utils.get_lib_fn('histogramMatchImageF%i' % ndim)
     itkimage = libfn(source_image.pointer, reference_image.pointer, number_of_histogram_bins, number_of_match_points, use_threshold_at_mean_intensity)
 
-    new_image = iio.ANTsImage(pixeltype='float', dimension=ndim, 
-                         components=source_image.components, pointer=itkimage).clone(inpixeltype)
+    new_image = iio2.from_pointer(itkimage).clone(inpixeltype)
     return new_image
 
 

--- a/ants/utils/integrate_velocity_field.py
+++ b/ants/utils/integrate_velocity_field.py
@@ -1,7 +1,7 @@
 
 __all__ = ['integrate_velocity_field']
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -42,8 +42,7 @@ def integrate_velocity_field(velocity_field,
     integrated_field = libfn(velocity_field.pointer, lower_integration_bound,
         upper_integration_bound, number_of_integration_steps)
 
-    new_image = iio.ANTsImage(pixeltype='float', dimension=(velocity_field.dimension-1),
-                         components=(velocity_field.dimension-1), pointer=integrated_field).clone('float')
+    new_image = iio2.from_pointer(integrated_field).clone('float')
     return new_image
 
 

--- a/ants/utils/invert_displacement_field.py
+++ b/ants/utils/invert_displacement_field.py
@@ -1,7 +1,7 @@
 
 __all__ = ['invert_displacement_field']
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -45,8 +45,7 @@ def invert_displacement_field(displacement_field,
         maximum_number_of_iterations, mean_error_tolerance_threshold, 
         max_error_tolerance_threshold, enforce_boundary_condition)
 
-    new_image = iio.ANTsImage(pixeltype='float', dimension=displacement_field.dimension, 
-                         components=displacement_field.dimension, pointer=inverse_field).clone('float')
+    new_image = iio2.from_pointer(inverse_field).clone('float')
     return new_image
 
 

--- a/ants/utils/pad_image.py
+++ b/ants/utils/pad_image.py
@@ -3,7 +3,7 @@ __all__ = ['pad_image']
 
 import math
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -72,8 +72,7 @@ def pad_image(image, shape=None, pad_width=None, value=0.0, return_padvals=False
     libfn = utils.get_lib_fn('padImage')
     itkimage = libfn(image.pointer, lower_pad_vals, upper_pad_vals, value)
 
-    new_image = iio.ANTsImage(pixeltype='float', dimension=ndim,
-                         components=image.components, pointer=itkimage).clone(inpixeltype)
+    new_image = iio2.from_pointer(itkimage).clone(inpixeltype)
     if return_padvals:
         return new_image, lower_pad_vals, upper_pad_vals
     else:

--- a/ants/utils/scalar_rgb_vector.py
+++ b/ants/utils/scalar_rgb_vector.py
@@ -101,8 +101,7 @@ def rgb_to_vector(image):
     idim = image.dimension
     libfn = utils.get_lib_fn('RgbToVector%i' % idim)
     new_ptr = libfn(image.pointer)
-    new_img = iio.ANTsImage(pixeltype=image.pixeltype, dimension=image.dimension, 
-                            components=3, pointer=new_ptr, is_rgb=False)
+    new_img = iio2.from_pointer(new_ptr)
     return new_img
 
 
@@ -132,7 +131,6 @@ def vector_to_rgb(image):
     idim = image.dimension
     libfn = utils.get_lib_fn('VectorToRgb%i' % idim)
     new_ptr = libfn(image.pointer)
-    new_img = iio.ANTsImage(pixeltype=image.pixeltype, dimension=image.dimension, 
-                            components=3, pointer=new_ptr, is_rgb=True)
+    new_img = iio2.from_pointer(new_ptr)
     return new_img
 

--- a/ants/utils/simulate_displacement_field.py
+++ b/ants/utils/simulate_displacement_field.py
@@ -2,7 +2,7 @@ __all__ = ["simulate_displacement_field"]
 
 import numpy as np
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -74,18 +74,14 @@ def simulate_displacement_field(domain_image,
         libfn = utils.get_lib_fn("simulateBsplineDisplacementField%iD" % image_dimension)
         field = libfn(domain_image.pointer, number_of_random_points, sd_noise, 
                       enforce_stationary_boundary, number_of_fitting_levels, number_of_control_points)
-        bspline_field = iio.ANTsImage(pixeltype='float', 
-            dimension=image_dimension, components=image_dimension,
-            pointer=field).clone('float')
+        bspline_field = iio2.from_pointer(field).clone('float')
         return bspline_field
 
     elif field_type == 'exponential':
         libfn = utils.get_lib_fn("simulateExponentialDisplacementField%iD" % image_dimension)
         field = libfn(domain_image.pointer, number_of_random_points, sd_noise, 
                       enforce_stationary_boundary, sd_smoothing)
-        exp_field = iio.ANTsImage(pixeltype='float', 
-            dimension=image_dimension, components=image_dimension,
-            pointer=field).clone('float')
+        exp_field = iio2.from_pointer(field).clone('float')
         return exp_field
 
     else:  

--- a/ants/utils/slice_image.py
+++ b/ants/utils/slice_image.py
@@ -3,7 +3,7 @@ __all__ = ['slice_image']
 
 import math
 
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -45,7 +45,6 @@ def slice_image(image, axis, idx, collapse_strategy=0):
     libfn = utils.get_lib_fn('sliceImage')
     itkimage = libfn(image.pointer, axis, idx, collapse_strategy)
 
-    return iio.ANTsImage(pixeltype='float', dimension=ndim-1, 
-                         components=image.components, pointer=itkimage).clone(inpixeltype)
+    return iio2.from_pointer(itkimage).clone(inpixeltype)
 
 

--- a/ants/utils/smooth_image.py
+++ b/ants/utils/smooth_image.py
@@ -6,7 +6,7 @@ __all__ = ['smooth_image']
 import math
 
 from .. import utils
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 
 
 
@@ -26,8 +26,7 @@ def _smooth_image_helper(image, sigma, sigma_in_physical_coordinates=True, FWHM=
 
     smooth_image_fn = utils.get_lib_fn('SmoothImage')
     outimage = smooth_image_fn(image_float.pointer, sigma, sigma_in_physical_coordinates, max_kernel_width)
-    ants_outimage = iio.ANTsImage(pixeltype='float', dimension=image.dimension,
-                                components=image.components, pointer=outimage)
+    ants_outimage = iio2.from_pointer(outimage)
     return ants_outimage
 
 

--- a/ants/utils/weingarten_image_curvature.py
+++ b/ants/utils/weingarten_image_curvature.py
@@ -4,7 +4,7 @@ __all__ = ['weingarten_image_curvature']
 import numpy as np
 
 from .. import core
-from ..core import ants_image as iio
+from ..core import ants_image as iio, ants_image_io as iio2
 from .. import utils
 
 
@@ -60,8 +60,7 @@ def weingarten_image_curvature(image, sigma=1.0, opt='mean'):
 
     libfn = utils.get_lib_fn('weingartenImageCurvature')
     mykout = libfn(temp.pointer, sigma, optnum)
-    mykout = iio.ANTsImage(pixeltype=image.pixeltype, dimension=3,
-                            components=image.components, pointer=mykout)
+    mykout = iio2.from_pointer(mykout)
     if image.dimension == 3:
         return mykout
     elif image.dimension == 2:

--- a/src/antsImage.cxx
+++ b/src/antsImage.cxx
@@ -96,6 +96,19 @@ void local_antsImage(nb::module_ &m) {
     m.def("ptrstr", &ptrstr<itk::Image<itk::RGBPixel<float>,2>>);
     m.def("ptrstr", &ptrstr<itk::Image<itk::RGBPixel<float>,3>>);
 
+    m.def("getComponents", &getComponents<itk::VectorImage<unsigned char,2>>);
+    m.def("getComponents", &getComponents<itk::VectorImage<unsigned char,3>>);
+    m.def("getComponents", &getComponents<itk::VectorImage<unsigned char,4>>);
+    m.def("getComponents", &getComponents<itk::VectorImage<unsigned int,2>>);
+    m.def("getComponents", &getComponents<itk::VectorImage<unsigned int,3>>);
+    m.def("getComponents", &getComponents<itk::VectorImage<unsigned int,4>>);
+    m.def("getComponents",  &getComponents<itk::VectorImage<float,2>>);
+    m.def("getComponents",  &getComponents<itk::VectorImage<float,3>>);
+    m.def("getComponents",  &getComponents<itk::VectorImage<float,4>>);
+    m.def("getComponents",  &getComponents<itk::VectorImage<double,2>>);
+    m.def("getComponents",  &getComponents<itk::VectorImage<double,3>>);
+    m.def("getComponents",  &getComponents<itk::VectorImage<double,4>>);
+
     m.def("getShape",  &getShape<itk::Image<unsigned char,2>>);
     m.def("getShape",  &getShape<itk::Image<unsigned char,3>>);
     m.def("getShape",  &getShape<itk::Image<unsigned char,4>>);

--- a/src/antsImage.h
+++ b/src/antsImage.h
@@ -90,6 +90,13 @@ std::list<int> getShape( AntsImage<ImageType> & myPointer )
 
 
 template <typename ImageType>
+int getComponents( AntsImage<ImageType> & myPointer )
+{
+    typename ImageType::Pointer image = myPointer.ptr;
+    return image->GetNumberOfComponentsPerPixel();
+}
+
+template <typename ImageType>
 std::vector<double> getOrigin( AntsImage<ImageType> & myPointer )
 {
     typename ImageType::Pointer image = myPointer.ptr;


### PR DESCRIPTION
Currently, you have to manually input a bunch of extra information when creating an ANTsImage internally from an ITK pointer, e.g.:

```python
img = iio.ANTsImage(pixeltype='float', dimension=2, components=1, pointer=itk_image)
```

Information such as pixeltype, dimension, components, is_rgb, etc is not only redundant to what is contained in the pointer, it is also vulnerable to bugs because it is not coupled to the one source of truth (the pointer to the actual image). If someone input the wrong dimension.. it would not be caught. 

This PR makes it so ANTsImage instances are created from only the pointer and all that extra info is extracted from the pointer. It is more robust and also makes it eventually easier to refactor the internal import system. The above line would be replaced with this:

```python
img = iio2.from_pointer(itk_image)
```

All of the info is still available as usual - no changes there.