### PR TITLE
ENH: check for transform instance before writing to file

### DIFF
--- a/ants/core/ants_transform_io.py
+++ b/ants/core/ants_transform_io.py
@@ -375,6 +375,9 @@ def write_transform(transform, filename):
     >>> ants.write_transform(tx, '~/desktop/tx.mat')
     >>> tx2 = ants.read_transform('~/desktop/tx.mat')
     """
+    if not isinstance(transform, tio.ANTsTransform):
+        raise Exception('Only ANTsTransform instances can be written to file. Check that you are not passing in a filepath to a saved transform.')
+    
     filename = os.path.expanduser(filename)
     libfn = utils.get_lib_fn("writeTransform")
     libfn(transform.pointer, filename)

--- a/tests/test_core_ants_transform_io.py
+++ b/tests/test_core_ants_transform_io.py
@@ -113,7 +113,11 @@ class TestModule_ants_transform_io(unittest.TestCase):
         mytx = ants.registration(fixed=fi, moving=mi, type_of_transform = ('SyN') )
         vec = ants.image_read( mytx['fwdtransforms'][0] )
         atx = ants.transform_from_displacement_field( vec )
-        field = ants.transform_to_displacement_field( atx, fi )    
+        field = ants.transform_to_displacement_field( atx, fi )   
+        
+    def test_catch_error(self):
+        with self.assertRaises(Exception):
+            ants.write_transform(123, 'test.mat') 
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Very small pr that checks that the object passed into `write_transform` is actually an antstransform instance and provides a more informative error message.