### PR TITLE
FIX: image indexing returns image where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,13 @@ find_package(Python 3.8
 find_package(nanobind CONFIG REQUIRED)
 
 # TODO: make this run only if ITK + ANTs are not already built
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
-  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
-else()
-  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
-  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
-endif()
+#if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
+#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
+#else()
+#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
+#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
+#endif()
 
 # ITK
 set(ITK_DIR "./itkbuild")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,13 @@ find_package(Python 3.8
 find_package(nanobind CONFIG REQUIRED)
 
 # TODO: make this run only if ITK + ANTs are not already built
-#if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
-#  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
-#else()
-#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
-#  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
-#endif()
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.bat)
+  execute_process(COMMAND cmd /c ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.bat)
+else()
+  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ITK.sh)
+  execute_process(COMMAND bash ${PROJECT_SOURCE_DIR}/scripts/configure_ANTs.sh)
+endif()
 
 # ITK
 set(ITK_DIR "./itkbuild")

--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -493,17 +493,6 @@ class ANTsImage(object):
         new_array = this_array != other
         return self.new_image_like(new_array.astype('uint8'))
 
-    def __getitem__2(self, idx):
-        if self._array is None:
-            self._array = self.numpy()
-
-        if is_image(idx):
-            if not ants.image_physical_space_consistency(self, idx):
-                raise ValueError('images do not occupy same physical space')
-            return self._array.__getitem__(idx.numpy().astype('bool'))
-        else:
-            return self._array.__getitem__(idx)
-        
     def __getitem__(self, idx):
         if self.has_components:
             return ants.merge_channels([

--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -493,7 +493,7 @@ class ANTsImage(object):
         new_array = this_array != other
         return self.new_image_like(new_array.astype('uint8'))
 
-    def __getitem__(self, idx):
+    def __getitem__2(self, idx):
         if self._array is None:
             self._array = self.numpy()
 
@@ -503,9 +503,57 @@ class ANTsImage(object):
             return self._array.__getitem__(idx.numpy().astype('bool'))
         else:
             return self._array.__getitem__(idx)
+        
+    def __getitem__(self, idx):
+        if self.has_components:
+            return ants.merge_channels([
+                img[idx] for img in ants.split_channels(self)
+            ])
+        
+        if isinstance(idx, ANTsImage):
+            if not ants.image_physical_space_consistency(self, idx):
+                raise ValueError('images do not occupy same physical space')
+            return self.numpy().__getitem__(idx.numpy().astype('bool'))
+    
+        ndim = len(idx)
+        sizes = list(self.shape)
+        starts = [0] * ndim
+        
+        for i in range(ndim):
+            ti = idx[i]
+            if isinstance(ti, slice):
+                if ti.start:
+                    starts[i] = ti.start
+                if ti.stop:
+                    sizes[i] = ti.stop - starts[i]
+                else:
+                    sizes[i] = self.shape[i] - starts[i]
+                    
+                if ti.stop and ti.start:
+                    if ti.stop < ti.start:
+                        raise Exception('Reverse indexing is not supported.')
+                
+            elif isinstance(ti, int):
+                starts[i] = ti
+                sizes[i] = 0
+                
+            if sizes[i] == 0:
+                ndim -= 1
+        
+        if ndim < 2:
+            return self.numpy().__getitem__(idx)
+        
+        libfn = get_lib_fn('getItem%i' % ndim)
+        new_ptr = libfn(self.pointer, starts, sizes)
+        new_image = from_pointer(new_ptr)
+        return new_image
 
     def __setitem__(self, idx, value):
         arr = self.view()
+        
+        if is_image(value):
+            value = value.numpy()
+            
         if is_image(idx):
             if not ants.image_physical_space_consistency(self, idx):
                 raise ValueError('images do not occupy same physical space')

--- a/ants/ops/weingarten_image_curvature.py
+++ b/ants/ops/weingarten_image_curvature.py
@@ -42,7 +42,7 @@ def weingarten_image_curvature(image, sigma=1.0, opt='mean'):
         d = image.shape
         temp = np.zeros(list(d)+[10])
         for k in range(1,7):
-            voxvals = image[:d[0],:d[1]]
+            voxvals = image[:d[0],:d[1]].numpy()
             temp[:d[0],:d[1],k] = voxvals
         temp = ants.from_numpy(temp)
         myspc = image.spacing

--- a/ants/plotting/plot_grid.py
+++ b/ants/plotting/plot_grid.py
@@ -153,17 +153,17 @@ def plot_grid(
 
     def slice_image(img, axis, idx):
         if axis == 0:
-            return img[idx, :, :]
+            return img[idx, :, :].numpy()
         elif axis == 1:
-            return img[:, idx, :]
+            return img[:, idx, :].numpy()
         elif axis == 2:
-            return img[:, :, idx]
+            return img[:, :, idx].numpy()
         elif axis == -1:
-            return img[:, :, idx]
+            return img[:, :, idx].numpy()
         elif axis == -2:
-            return img[:, idx, :]
+            return img[:, idx, :].numpy()
         elif axis == -3:
-            return img[idx, :, :]
+            return img[idx, :, :].numpy()
         else:
             raise ValueError("axis %i not valid" % axis)
 

--- a/src/antsGetItem.cxx
+++ b/src/antsGetItem.cxx
@@ -1,0 +1,78 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/list.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/shared_ptr.h>
+
+#include "itkImage.h"
+#include <itkExtractImageFilter.h>
+
+#include "antsImage.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+template <typename ImageType, class PixelType, unsigned int ndim>
+AntsImage<itk::Image<PixelType, ndim>> getItem( AntsImage<ImageType> & antsImage, 
+                              std::vector<unsigned long> starts, 
+                              std::vector<unsigned long> sizes )
+{
+    typename ImageType::Pointer image = antsImage.ptr;
+
+    using OutImageType = itk::Image<PixelType, ndim>;
+
+    typename ImageType::IndexType desiredStart;
+    typename ImageType::SizeType desiredSize;
+
+    for( int i = 0 ; i < starts.size(); ++i )
+    {
+        desiredStart[i] = starts[i];
+        desiredSize[i] = sizes[i];
+    }
+
+    typename ImageType::RegionType desiredRegion(desiredStart, desiredSize);
+
+    using FilterType = itk::ExtractImageFilter<ImageType, OutImageType>;
+    typename FilterType::Pointer filter = FilterType::New();
+    filter->SetExtractionRegion(desiredRegion);
+    filter->SetInput(image);
+    filter->SetDirectionCollapseToIdentity(); // This is required.
+    filter->Update();
+
+    FixNonZeroIndex<OutImageType>( filter->GetOutput() );
+    AntsImage<OutImageType> outImage = { filter->GetOutput() };
+    return outImage;
+}
+
+
+void local_antsGetItem(nb::module_ &m) {
+    m.def("getItem2",   &getItem<itk::Image<float,2>, float, 2>);
+    m.def("getItem2",   &getItem<itk::Image<float,3>, float, 2>);  
+    m.def("getItem2",   &getItem<itk::Image<float,4>, float, 2>);  
+    m.def("getItem3",   &getItem<itk::Image<float,3>, float, 3>);  
+    m.def("getItem3",   &getItem<itk::Image<float,4>, float, 3>);  
+    m.def("getItem4",   &getItem<itk::Image<float,4>, float, 4>);  
+    
+    m.def("getItem2",   &getItem<itk::Image<unsigned char,2>, unsigned char, 2>);
+    m.def("getItem2",   &getItem<itk::Image<unsigned char,3>, unsigned char, 2>);
+    m.def("getItem2",   &getItem<itk::Image<unsigned char,4>, unsigned char, 2>);
+    m.def("getItem3",   &getItem<itk::Image<unsigned char,3>, unsigned char, 3>);
+    m.def("getItem3",   &getItem<itk::Image<unsigned char,4>, unsigned char, 3>);
+    m.def("getItem4",   &getItem<itk::Image<unsigned char,4>, unsigned char, 4>);
+
+    m.def("getItem2",   &getItem<itk::Image<unsigned int,2>, unsigned int, 2>);
+    m.def("getItem2",   &getItem<itk::Image<unsigned int,3>, unsigned int, 2>);
+    m.def("getItem2",   &getItem<itk::Image<unsigned int,4>, unsigned int, 2>);
+    m.def("getItem3",   &getItem<itk::Image<unsigned int,3>, unsigned int, 3>);
+    m.def("getItem3",   &getItem<itk::Image<unsigned int,4>, unsigned int, 3>);
+    m.def("getItem4",   &getItem<itk::Image<unsigned int,4>, unsigned int, 4>);
+
+    m.def("getItem2",   &getItem<itk::Image<double,2>, double, 2>);
+    m.def("getItem2",   &getItem<itk::Image<double,3>, double, 2>);
+    m.def("getItem2",   &getItem<itk::Image<double,4>, double, 2>);
+    m.def("getItem3",   &getItem<itk::Image<double,3>, double, 3>);
+    m.def("getItem3",   &getItem<itk::Image<double,4>, double, 3>);
+    m.def("getItem4",   &getItem<itk::Image<double,4>, double, 4>);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 
 #include "addNoiseToImage.cxx"
 #include "antiAlias.cxx"
+#include "antsGetItem.cxx"
 #include "antsImage.cxx"
 #include "antsImageClone.cxx"
 #include "antsImageHeaderInfo.cxx"
@@ -60,6 +61,7 @@ namespace nb = nanobind;
 
 void local_addNoiseToImage(nb::module_ &);
 void local_antiAlias(nb::module_ &);
+void local_antsGetItem(nb::module_ &);
 void local_antsImage(nb::module_ &);
 void local_antsImageClone(nb::module_ &);
 void local_antsImageHeaderInfo(nb::module_ &);
@@ -117,6 +119,7 @@ void wrap_TileImages(nb::module_ &);
 NB_MODULE(lib, m) {
     local_addNoiseToImage(m);
     local_antiAlias(m);
+    local_antsGetItem(m);
     local_antsImage(m);
     local_antsImageClone(m);
     local_antsImageHeaderInfo(m);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -22,6 +22,7 @@ pushd "$(dirname "$0")"
 
 echo "Running core tests"
 $PYCMD test_core_ants_image.py $@
+$PYCMD test_core_ants_image_indexing.py $@
 $PYCMD test_core_ants_image_io.py $@
 $PYCMD test_core_ants_transform.py $@
 $PYCMD test_core_ants_transform_io.py $@

--- a/tests/test_core_ants_image.py
+++ b/tests/test_core_ants_image.py
@@ -485,14 +485,13 @@ class TestClass_ANTsImage(unittest.TestCase):
                 img3 = img != img2
 
     def test__getitem__(self):
-        #self.setUp()
         for img in self.imgs:
             if img.dimension == 2:
                 img2 = img[6:9,6:9]
-                nptest.assert_allclose(img2, img.numpy()[6:9,6:9])
+                nptest.assert_allclose(img2.numpy(), img.numpy()[6:9,6:9])
             elif img.dimension == 3:
                 img2 = img[6:9,6:9,6:9]
-                nptest.assert_allclose(img2, img.numpy()[6:9,6:9,6:9])
+                nptest.assert_allclose(img2.numpy(), img.numpy()[6:9,6:9,6:9])
 
             # get from another image
             img2 = img.clone()
@@ -503,7 +502,6 @@ class TestClass_ANTsImage(unittest.TestCase):
                 xx = img[img2]
 
     def test__setitem__(self):
-        #self.setUp()
         for img in self.imgs:
             if img.dimension == 2:
                 img[6:9,6:9] = 6.9

--- a/tests/test_core_ants_image_indexing.py
+++ b/tests/test_core_ants_image_indexing.py
@@ -1,0 +1,209 @@
+"""
+Test ants_image.py
+
+nptest.assert_allclose
+self.assertEqual
+self.assertTrue
+
+"""
+
+import os
+import unittest
+from common import run_tests
+
+from tempfile import mktemp
+
+import numpy as np
+import numpy.testing as nptest
+
+import ants
+
+
+class TestClass_AntsImageIndexing(unittest.TestCase):
+    
+    def setUp(self):
+        pass
+    def tearDown(self):
+        pass
+    
+    def test_pixeltype_2d(self):
+        img = ants.image_read(ants.get_data('r16'))
+        for ptype in ['unsigned char', 'unsigned int', 'float', 'double']:
+            img = img.clone(ptype)
+            self.assertEqual(img.pixeltype, ptype)
+            img2 = img[:10,:10]
+            self.assertEqual(img2.pixeltype, ptype)
+            
+    def test_pixeltype_3d(self):
+        img = ants.image_read(ants.get_data('mni'))
+        for ptype in ['unsigned char', 'unsigned int', 'float', 'double']:
+            img = img.clone(ptype)
+            self.assertEqual(img.pixeltype, ptype)
+            img2 = img[:10,:10,:10]
+            self.assertEqual(img2.pixeltype, ptype)
+            img3 = img[:10,:10,10]
+            self.assertEqual(img3.pixeltype, ptype)
+    
+    def test_2d(self):
+        img = ants.image_read(ants.get_data('r16'))
+        
+        img2 = img[:10,:10]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[:5,:5]
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = img[1:20,1:10]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[:5,:5]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[:5,4:5]
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = img[5:5,5:5]
+        
+        # down to 1d
+        arr = img[10,:]
+        self.assertTrue(isinstance(arr, np.ndarray))
+        
+        # single value
+        arr = img[10,10]
+        
+    def test_2d_image_index(self):
+        img = ants.image_read(ants.get_data('r16'))
+        idx = img > 200
+        
+        # acts like a mask
+        img2 = img[idx]
+
+    def test_3d(self):
+        img = ants.image_read(ants.get_data('mni'))
+        
+        img2 = img[:10,:10,:10]
+        self.assertEqual(img2.dimension, 3)
+        img2 = img[:5,:5,:5]
+        self.assertEqual(img2.dimension, 3)
+        img2 = img[1:20,1:10,1:15]
+        self.assertEqual(img2.dimension, 3)
+        img2 = img[:5,:5,:5]
+        self.assertEqual(img2.dimension, 3)
+        
+        # down to 2d
+        img2 = img[10,:,:]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[:,10,:]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[:,:,10]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[10,:20,:20]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[:20,10,:]
+        self.assertEqual(img2.dimension, 2)
+        img2 = img[2:20,3:30,10]
+        self.assertEqual(img2.dimension, 2)
+        
+        # down to 1d
+        arr = img[10,:,10]
+        self.assertTrue(isinstance(arr, np.ndarray))
+        arr = img[10,:,5]
+        self.assertTrue(isinstance(arr, np.ndarray))
+        
+        # single value
+        arr = img[10,10,10]
+        
+    def test_double_indexing(self):
+        img = ants.image_read(ants.get_data('mni'))
+        img2 = img[20:,:,:]
+        self.assertEqual(img2.shape, (162,218,182))
+        
+        img3 = img[0,:,:]
+        self.assertEqual(img3.shape, (218,182))
+        
+    def test_reverse_error(self):
+        img = ants.image_read(ants.get_data('mni'))
+        with self.assertRaises(Exception):
+            img2 = img[20:10,:,:]
+            
+    def test_2d_vector(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2 = img[:10,:10]
+        
+        img_v = ants.merge_channels([img])
+        img_v2 = img_v[:10,:10]
+        
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[0]))
+
+    def test_2d_vector_multi(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2 = img[:10,:10]
+        
+        img_v = ants.merge_channels([img,img,img])
+        img_v2 = img_v[:10,:10]
+        
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[0]))
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[1]))
+        self.assertTrue(ants.allclose(img2, ants.split_channels(img_v2)[2]))
+        
+    def test_setting_3d(self):
+        img = ants.image_read(ants.get_data('mni'))
+        img2d = img[100,:,:]
+        
+        # setting a sub-image with an image
+        img2 = img + 10
+        img2[100,:,:] = img2d
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[100,:,:]))
+        
+        # setting a sub-image with an array
+        img2 = img + 10
+        img2[100,:,:] = img2d.numpy()
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[100,:,:]))
+        
+    def test_setting_2d(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2d = img[100,:]
+        
+        # setting a sub-image with an image
+        img2 = img + 10
+        img2[100,:] = img2d
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(np.allclose(img2d, img2[100,:]))
+        
+        
+    def test_setting_2d_sub_image(self):
+        img = ants.image_read(ants.get_data('r16'))
+        img2d = img[10:30,10:30]
+        
+        # setting a sub-image with an image
+        img2 = img + 10
+        img2[10:30,10:30] = img2d
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[10:30,10:30]))
+        
+        # setting a sub-image with an array
+        img2 = img + 10
+        img2[10:30,10:30] = img2d.numpy()
+        
+        self.assertFalse(ants.allclose(img, img2))
+        self.assertTrue(ants.allclose(img2d, img2[10:30,10:30]))
+    
+    def test_setting_correctness(self):
+        
+        img = ants.image_read(ants.get_data('r16')) * 0
+        self.assertEqual(img.sum(), 0)
+        
+        img2 = img[10:30,10:30]
+        img2 = img2 + 10
+        self.assertEqual(img2.mean(), 10)
+        
+        img[:20,:20] = img2
+        self.assertEqual(img.sum(), img2.sum())
+        self.assertEqual(img.numpy()[:20,:20].sum(), img2.sum())
+        self.assertNotEqual(img.numpy()[10:30,10:30].sum(), img2.sum())
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Previously, indexing an ants image always returned a numpy array. This fix ensures that an ants image is returned where possible. No changes are made to indexing with another ants image or to setting behavior.