### PR TITLE
ENH: support 2d images on slice_image function

### DIFF
--- a/ants/ops/slice_image.py
+++ b/ants/ops/slice_image.py
@@ -32,9 +32,13 @@ def slice_image(image, axis, idx, collapse_strategy=0):
     >>> mni = ants.image_read(ants.get_data('mni'))
     >>> mni2 = ants.slice_image(mni, axis=1, idx=100)
     """
-    if image.dimension < 3:
-        raise ValueError('image must have at least 3 dimensions')
-
+    if image.dimension == 2:
+        if axis == 0:
+            return image[idx,:]
+        elif axis == 1:
+            return image[:,idx]
+        raise Exception('Parameters not understood for 2D image.')
+        
     if collapse_strategy != 0 and collapse_strategy != 1 and collapse_strategy != 2:
         raise ValueError('collapse_strategy must be 0, 1, or 2.') 
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -40,6 +40,9 @@ $PYCMD test_segmentation.py $@
 echo "Running utils tests"
 $PYCMD test_utils.py $@
 
+echo "Running ops tests"
+$PYCMD test_ops.py $@
+
 echo "Running plotting tests"
 $PYCMD test_plotting.py $@
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,66 @@
+import os
+import unittest
+from common import run_tests
+
+import ants
+
+import numpy as np
+import numpy.testing as nptest
+
+
+class Test_slice_image(unittest.TestCase):
+    """
+    Test ants.ANTsImage class
+    """
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_slice_image_2d(self):
+        """
+        Test that resampling an image doesnt cause the resampled
+        image to have NaNs - previously caused by resampling an
+        image of type DOUBLE
+        """
+        img = ants.image_read(ants.get_ants_data('r16'))
+        
+        img2 = ants.slice_image(img, 0, 100)
+        self.assertTrue(isinstance(img2, np.ndarray))
+        
+        img2 = ants.slice_image(img, 1, 100)
+        self.assertTrue(isinstance(img2, np.ndarray))
+        
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 2, 100)
+        
+    def test_slice_image_3d(self):
+        """
+        Test that resampling an image doesnt cause the resampled
+        image to have NaNs - previously caused by resampling an
+        image of type DOUBLE
+        """
+        img = ants.image_read(ants.get_ants_data('mni'))
+        
+        img2 = ants.slice_image(img, 0, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = ants.slice_image(img, 1, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = ants.slice_image(img, 2, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = ants.slice_image(img.clone('unsigned int'), 2, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 3, 100)
+            
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 2, 100, collapse_strategy=23)
+
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
The `slice_image` function currently does not support 2D images but it should. This PR changes that.