### PR TITLE
FIX: new_image_like arg typo

### DIFF
--- a/ants/core/__init__.py
+++ b/ants/core/__init__.py
@@ -5,6 +5,7 @@ from .ants_image_io import (image_header_info,
                             image_write,
                             make_image,
                             from_numpy,
+                            from_numpy_like,
                             new_image_like)
 from .ants_image import (copy_image_info,
                          set_origin,

--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -10,6 +10,7 @@ __all__ = [
     "image_write",
     "make_image",
     "from_numpy",
+    "from_numpy_like",
     "new_image_like"
 ]
 
@@ -487,7 +488,7 @@ def clone(self, pixeltype=None):
 copy = clone
 
 @image_method
-def new_image_like(self, data):
+def new_image_like(image, data):
     """
     Create a new ANTsImage with the same header information, but with
     a new image array.
@@ -505,13 +506,16 @@ def new_image_like(self, data):
     """
     if not isinstance(data, np.ndarray):
         raise ValueError('data must be a numpy array')
-    if not self.has_components:
-        if data.shape != self.shape:
-            raise ValueError('given array shape (%s) and image array shape (%s) do not match' % (data.shape, self.shape))
+    if not image.has_components:
+        if data.shape != image.shape:
+            raise ValueError('given array shape (%s) and image array shape (%s) do not match' % (data.shape, image.shape))
     else:
-        if (data.shape[-1] != self.components) or (data.shape[:-1] != self.shape):
-            raise ValueError('given array shape (%s) and image array shape (%s) do not match' % (data.shape[1:], self.shape))
+        if (data.shape[-1] != image.components) or (data.shape[:-1] != image.shape):
+            raise ValueError('given array shape (%s) and image array shape (%s) do not match' % (data.shape[1:], image.shape))
 
-    return from_numpy(data, origin=self.origin,
-        spacing=self.spacing, direction=self.direction,
-        has_components=self.has_components)
+    return from_numpy(data, origin=image.origin,
+        spacing=image.spacing, direction=image.direction,
+        has_components=image.has_components)
+    
+def from_numpy_like(data, image):
+    return new_image_like(image, data)

--- a/tests/test_core_ants_image.py
+++ b/tests/test_core_ants_image.py
@@ -178,6 +178,15 @@ class TestClass_ANTsImage(unittest.TestCase):
             vecimg = ants.from_numpy(np.random.randn(69,12,3).astype('float32'), has_components=True)
             new_data = np.random.randn(69,12,4).astype('float32')
             vecimg.new_image_like(new_data)
+            
+    def test_from_numpy_like(self):
+        img = ants.image_read(ants.get_data('mni'))
+        
+        arr = img.numpy()
+        arr *= 2
+        img2 = ants.from_numpy_like(arr, img)
+        self.assertTrue(ants.image_physical_space_consistency(img, img2))
+        self.assertEqual(img2.mean() / img.mean(), 2)
 
     def test_to_file(self):
         #self.setUp()


### PR DESCRIPTION
The `new_image_like` function had a typo where the argument was name "self" because it was originally attached to the ants image class. Now it is an `@image_method` function. This PR fixes that and also adds a semi-alias function `from_numpy_like` that fit in better with the api given the `from_numpy` function... except the args are switched.