### PR TITLE
Fix: raise for bad slice axis; ENH: support slicing vector images

### DIFF
--- a/ants/ops/slice_image.py
+++ b/ants/ops/slice_image.py
@@ -32,6 +32,12 @@ def slice_image(image, axis, idx, collapse_strategy=0):
     >>> mni = ants.image_read(ants.get_data('mni'))
     >>> mni2 = ants.slice_image(mni, axis=1, idx=100)
     """
+    if axis == -1:
+        axis = image.dimension - 1
+        
+    if axis > (image.dimension - 1) or axis < 0:
+        raise Exception('The axis must be between 0 and image.dimension - 1')
+        
     if image.dimension == 2:
         if axis == 0:
             return image[idx,:]

--- a/ants/ops/slice_image.py
+++ b/ants/ops/slice_image.py
@@ -2,7 +2,7 @@
 __all__ = ['slice_image']
 
 import math
-
+import numpy as np
 import ants
 from ants.decorators import image_method
 from ants.internal import get_lib_fn
@@ -32,6 +32,13 @@ def slice_image(image, axis, idx, collapse_strategy=0):
     >>> mni = ants.image_read(ants.get_data('mni'))
     >>> mni2 = ants.slice_image(mni, axis=1, idx=100)
     """
+    if image.has_components:
+        ilist = ants.split_channels(image)
+        if image.dimension == 2:
+            return np.stack(tuple([i.slice_image(axis, idx, collapse_strategy) for i in ilist]), axis=-1)
+        else:
+            return ants.merge_channels([i.slice_image(axis, idx, collapse_strategy) for i in ilist])
+    
     if axis == -1:
         axis = image.dimension - 1
         

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -42,6 +42,9 @@ class Test_slice_image(unittest.TestCase):
             img2 = ants.slice_image(img, 4, 100)
             
         img2 = ants.slice_image(img, -1, 100)
+        img3 = ants.slice_image(img, -1, 100)
+        self.assertTrue(np.allclose(img2, img3))
+
         
     def test_slice_image_3d(self):
         """
@@ -70,6 +73,8 @@ class Test_slice_image(unittest.TestCase):
             img2 = ants.slice_image(img, 2, 100, collapse_strategy=23)
             
         img2 = ants.slice_image(img, -1, 100)
+        img3 = ants.slice_image(img, -1, 100)
+        self.assertTrue(ants.allclose(img2, img3))
 
 
 if __name__ == '__main__':

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -34,6 +34,14 @@ class Test_slice_image(unittest.TestCase):
         
         with self.assertRaises(Exception):
             img2 = ants.slice_image(img, 2, 100)
+            
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, -3, 100)
+        
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 4, 100)
+            
+        img2 = ants.slice_image(img, -1, 100)
         
     def test_slice_image_3d(self):
         """
@@ -60,6 +68,8 @@ class Test_slice_image(unittest.TestCase):
             
         with self.assertRaises(Exception):
             img2 = ants.slice_image(img, 2, 100, collapse_strategy=23)
+            
+        img2 = ants.slice_image(img, -1, 100)
 
 
 if __name__ == '__main__':

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -42,7 +42,7 @@ class Test_slice_image(unittest.TestCase):
             img2 = ants.slice_image(img, 4, 100)
             
         img2 = ants.slice_image(img, -1, 100)
-        img3 = ants.slice_image(img, -1, 100)
+        img3 = ants.slice_image(img, 1, 100)
         self.assertTrue(np.allclose(img2, img3))
 
         
@@ -73,7 +73,7 @@ class Test_slice_image(unittest.TestCase):
             img2 = ants.slice_image(img, 2, 100, collapse_strategy=23)
             
         img2 = ants.slice_image(img, -1, 100)
-        img3 = ants.slice_image(img, -1, 100)
+        img3 = ants.slice_image(img, 2, 100)
         self.assertTrue(ants.allclose(img2, img3))
 
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -45,7 +45,29 @@ class Test_slice_image(unittest.TestCase):
         img3 = ants.slice_image(img, 1, 100)
         self.assertTrue(np.allclose(img2, img3))
 
+    def test_slice_image_2d_vector(self):
+        img0 = ants.image_read(ants.get_ants_data('r16'))
+        img = ants.merge_channels([img0,img0,img0])
+
+        img2 = ants.slice_image(img, 0, 100)
+        self.assertTrue(isinstance(img2, np.ndarray))
         
+        img2 = ants.slice_image(img, 1, 100)
+        self.assertTrue(isinstance(img2, np.ndarray))
+        
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 2, 100)
+            
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, -3, 100)
+        
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 4, 100)
+            
+        img2 = ants.slice_image(img, -1, 100)
+        img3 = ants.slice_image(img, 1, 100)
+        self.assertTrue(np.allclose(img2, img3))
+
     def test_slice_image_3d(self):
         """
         Test that resampling an image doesnt cause the resampled
@@ -53,6 +75,37 @@ class Test_slice_image(unittest.TestCase):
         image of type DOUBLE
         """
         img = ants.image_read(ants.get_ants_data('mni'))
+        
+        img2 = ants.slice_image(img, 0, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = ants.slice_image(img, 1, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = ants.slice_image(img, 2, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        img2 = ants.slice_image(img.clone('unsigned int'), 2, 100)
+        self.assertEqual(img2.dimension, 2)
+        
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 3, 100)
+            
+        with self.assertRaises(Exception):
+            img2 = ants.slice_image(img, 2, 100, collapse_strategy=23)
+            
+        img2 = ants.slice_image(img, -1, 100)
+        img3 = ants.slice_image(img, 2, 100)
+        self.assertTrue(ants.allclose(img2, img3))
+
+    def test_slice_image_3d_vector(self):
+        """
+        Test that resampling an image doesnt cause the resampled
+        image to have NaNs - previously caused by resampling an
+        image of type DOUBLE
+        """
+        img0 = ants.image_read(ants.get_ants_data('mni'))
+        img = ants.merge_channels([img0,img0,img0])
         
         img2 = ants.slice_image(img, 0, 100)
         self.assertEqual(img2.dimension, 2)


### PR DESCRIPTION
I realized that setting `axis = -1` in `slice_image()` caused a seg fault, so I am adding better error catching for the axis and supporting the axis=-1 as many other libraries do. I also need to be able to slice vector images so I implemented that.