### PR TITLE
ENH: support channels first for vector images

### DIFF
--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -51,6 +51,7 @@ class ANTsImage(object):
 
         """
         self.pointer = pointer
+        self.channels_first = False
         self._array = None
 
     @property
@@ -254,7 +255,8 @@ class ANTsImage(object):
         """
         array = np.array(self.view(single_components=single_components), copy=True, dtype=self.dtype)
         if self.has_components or (single_components == True):
-            array = np.rollaxis(array, 0, self.dimension+1)
+            if not self.channels_first:
+                array = np.rollaxis(array, 0, self.dimension+1)
         return array
 
     def astype(self, dtype):

--- a/ants/utils/channels.py
+++ b/ants/utils/channels.py
@@ -12,7 +12,7 @@ from ants.internal import get_lib_fn
 from ants.decorators import image_method
 
 
-def merge_channels(image_list):
+def merge_channels(image_list, channels_first=False):
     """
     Merge channels of multiple scalar ANTsImage types into one 
     multi-channel ANTsImage
@@ -31,9 +31,11 @@ def merge_channels(image_list):
     Example
     -------
     >>> import ants
-    >>> image = ants.image_read(ants.get_ants_data('r16'), 'float')
-    >>> image2 = ants.image_read(ants.get_ants_data('r16'), 'float')
+    >>> image = ants.image_read(ants.get_ants_data('r16'))
+    >>> image2 = ants.image_read(ants.get_ants_data('r16'))
     >>> image3 = ants.merge_channels([image,image2])
+    >>> image3 = ants.merge_channels([image,image2], channels_first=True)
+    >>> image3.numpy()
     >>> image3.components == 2
     """
     inpixeltype = image_list[0].pixeltype
@@ -49,7 +51,9 @@ def merge_channels(image_list):
     libfn = get_lib_fn('mergeChannels')
     image_ptr = libfn([image.pointer for image in image_list])
     
-    return ants.from_pointer(image_ptr)
+    image = ants.from_pointer(image_ptr)
+    image.channels_first = channels_first
+    return image
 
 @image_method
 def split_channels(image):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -925,6 +925,16 @@ class TestRandom(unittest.TestCase):
         s16 = ants.kmeans_segmentation( r16, 3 )['segmentation']
         s64 = ants.kmeans_segmentation( r64, 3 )['segmentation']
         stats = ants.hausdorff_distance(s16, s64)
+        
+    def test_channels_first(self):
+        import ants
+        image = ants.image_read(ants.get_ants_data('r16'))
+        image2 = ants.image_read(ants.get_ants_data('r16'))
+        img3 = ants.merge_channels([image,image2])
+        img4 = ants.merge_channels([image,image2], channels_first=True)
+        
+        self.assertTrue(np.allclose(img3.numpy()[:,:,0], img4.numpy()[0,:,:]))
+        self.assertTrue(np.allclose(img3.numpy()[:,:,1], img4.numpy()[1,:,:]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We need a good way to specify whether to put the channels first or last when converting a vector image to numpy. This is a basic step in that direction by adding the `channels_first` property to ants images. It defaults to False, which is the current behavior of putting the channels last.