### PR TITLE
ENH: support pickle and deepcopy for images

### DIFF
--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -565,7 +565,26 @@ class ANTsImage(object):
             '\t {:<10} : {}\n'.format('Origin', tuple([round(o,4) for o in self.origin]))+\
             '\t {:<10} : {}\n'.format('Direction', np.round(self.direction.flatten(),4))
         return s
-
+    
+    def __getstate__(self):
+        """
+        import ants
+        import pickle
+        import numpy as np
+        from copy import deepcopy
+        img = ants.image_read( ants.get_ants_data("r16"))
+        img_pickled = pickle.dumps(img)
+        img2 = pickle.loads(img_pickled)
+        img3 = deepcopy(img)
+        img += 10
+        print(img.mean(), img3.mean())
+        """
+        return self.numpy(), self.origin, self.spacing, self.direction, self.has_components, self.is_rgb
+    
+    def __setstate__(self, state):
+        data, origin, spacing, direction, has_components, is_rgb = state
+        image = ants.from_numpy(np.copy(data), origin=origin, spacing=spacing, direction=direction, has_components=has_components, is_rgb=is_rgb)
+        self.__dict__ = image.__dict__
 
 def copy_image_info(reference, target):
     """

--- a/tests/test_core_ants_image.py
+++ b/tests/test_core_ants_image.py
@@ -666,6 +666,23 @@ class TestModule_ants_image(unittest.TestCase):
             self.assertTrue(ants.allclose(img,img2))
             self.assertTrue(ants.allclose(img*6.9, img2*6.9))
             self.assertTrue(not ants.allclose(img, img2*6.9))
+            
+    def test_pickle(self):
+        import ants
+        import pickle
+        img = ants.image_read( ants.get_ants_data("mni"))
+        img_pickled = pickle.dumps(img)
+        img2 = pickle.loads(img_pickled)
+        
+        self.assertTrue(ants.allclose(img, img2))
+        self.assertTrue(ants.image_physical_space_consistency(img, img2))
+        
+        img = ants.image_read( ants.get_ants_data("r16"))
+        img_pickled = pickle.dumps(img)
+        img2 = pickle.loads(img_pickled)
+        
+        self.assertTrue(ants.allclose(img, img2))
+        self.assertTrue(ants.image_physical_space_consistency(img, img2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It was previously not possible to pickle ants images, so things like `deepcopy` failed. This PR adds basic pickle support via numpy. I had some random segfaults in some early versions of this PR but I believe the current version works well... something to keep an eye on anyways.

Example:

```python
import ants
import pickle
import numpy as np
from copy import deepcopy

img = ants.image_read( ants.get_ants_data("r16"))
img_pickled = pickle.dumps(img)
img2 = pickle.loads(img_pickled)
img3 = deepcopy(img)
img += 10
print(img.mean(), img2.mean())
print(img.mean(), img3.mean())
```