### PR TITLE
FIX: cast unsupported numpy dtypes in ants.from_numpy()

### DIFF
--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -89,12 +89,17 @@ def from_numpy(
     ANTsImage
         image with given data and any given information
     """
+    
+    # this is historic but should be removed once tests can pass without it
+    if str(data.dtype) == 'float64':
+        data = data.astype('float32')
+    
     # if dtype is not supported, cast to best available
     best_dtype = infer_dtype(data.dtype)
     if best_dtype != data.dtype:
         warnings.warn(f'Warning: The dtype {data.dtype} is not supported so the array will be casted to {best_dtype}. Cast it manually before calling `ants.from_numpy()` to remove this warning.')
         data = data.astype(best_dtype)
-        
+    
     img = _from_numpy(data.T.copy(), origin, spacing, direction, has_components, is_rgb)
     return img
 

--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -91,13 +91,12 @@ def from_numpy(
     """
     
     # this is historic but should be removed once tests can pass without it
-    if str(data.dtype) == 'float64':
+    if data.dtype.name == 'float64':
         data = data.astype('float32')
     
     # if dtype is not supported, cast to best available
     best_dtype = infer_dtype(data.dtype)
     if best_dtype != data.dtype:
-        warnings.warn(f'Warning: The dtype {data.dtype} is not supported so the array will be casted to {best_dtype}. Cast it manually before calling `ants.from_numpy()` to remove this warning.')
         data = data.astype(best_dtype)
     
     img = _from_numpy(data.T.copy(), origin, spacing, direction, has_components, is_rgb)

--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -20,7 +20,7 @@ import numpy as np
 import warnings
 
 import ants
-from ants.internal import get_lib_fn, short_ptype
+from ants.internal import get_lib_fn, short_ptype, infer_dtype
 from ants.decorators import image_method
 
 _supported_pclasses = {"scalar", "vector", "rgb", "rgba","symmetric_second_rank_tensor"}
@@ -89,7 +89,12 @@ def from_numpy(
     ANTsImage
         image with given data and any given information
     """
-    data = data.astype("float32") if data.dtype.name == "float64" else data
+    # if dtype is not supported, cast to best available
+    best_dtype = infer_dtype(data.dtype)
+    if best_dtype != data.dtype:
+        warnings.warn(f'Warning: The dtype {data.dtype} is not supported so the array will be casted to {best_dtype}. Cast it manually before calling `ants.from_numpy()` to remove this warning.')
+        data = data.astype(best_dtype)
+        
     img = _from_numpy(data.T.copy(), origin, spacing, direction, has_components, is_rgb)
     return img
 

--- a/ants/internal.py
+++ b/ants/internal.py
@@ -5,7 +5,21 @@ short_ptype_map = {"unsigned char": "UC",
                     "unsigned int": "UI",
                     "float": "F",
                     "double": "D"}
-    
+
+def infer_dtype(dtype):
+    # supported dtypes: uint8, uint32, float32, float64
+    exchange_map = {
+        'int8': 'uint32',
+        'int16': 'uint32',
+        'int32': 'uint32',
+        'int64': 'uint32',
+        'uint16': 'uint32',
+        'uint64': 'uint32',
+        'float16': 'float32'
+    }
+    new_dtype = exchange_map.get(str(dtype), dtype)
+    return new_dtype
+
 def short_ptype(pixeltype):
     return short_ptype_map[pixeltype]
 

--- a/ants/internal.py
+++ b/ants/internal.py
@@ -9,6 +9,7 @@ short_ptype_map = {"unsigned char": "UC",
 def infer_dtype(dtype):
     # supported dtypes: uint8, uint32, float32, float64
     exchange_map = {
+        'bool': 'uint8',
         'int8': 'uint32',
         'int16': 'uint32',
         'int32': 'uint32',

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -123,6 +123,20 @@ class Test_bugs(unittest.TestCase):
         # Erroneously returns all zeros.
         self.assertNotEqual(bspline_curve.sum(), 0)
 
-
+    def test_from_numpy_different_dtypes(self):
+        all_dtypes = ('int8',
+                      'int16',
+                      'int32',
+                      'int64',
+                      'uint16',
+                      'uint64',
+                      'float16')
+        arr = np.random.randn(100,100)
+        
+        for dtype in all_dtypes:
+            arr2 = arr.astype(dtype)
+            img = ants.from_numpy(arr2)
+            self.assertTrue(ants.is_image(img))
+        
 if __name__ == '__main__':
     run_tests()

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -124,7 +124,8 @@ class Test_bugs(unittest.TestCase):
         self.assertNotEqual(bspline_curve.sum(), 0)
 
     def test_from_numpy_different_dtypes(self):
-        all_dtypes = ('int8',
+        all_dtypes = ('bool',
+                      'int8',
                       'int16',
                       'int32',
                       'int64',


### PR DESCRIPTION
If you try to create an ants image from an array with an unsupported numpy dtype, it just fails. Since we only support 4 dtypes, we really should support automatically casting unsupported dtypes to supported ones. This PR does that.

The one question I have is whether it is good to warn the user that their data is being casted or to just do it silently. Having a bunch of warnings is annoying and pollutes the console, but I can see some people being confused that their data is in a different dtype otherwise.

Below is an example that fails.  The `int16` type is quite common for segmentation arrays which is how I discovered the error:

```python
import numpy as np
import ants

arr = np.random.randn(100,100).astype('int16')
img = ants.from_numpy(arr)
```