### PR TITLE
ENH: add components decorator

### DIFF
--- a/ants/decorators.py
+++ b/ants/decorators.py
@@ -1,3 +1,4 @@
+import ants
 from functools import wraps
 from ants.core.ants_image import ANTsImage
 
@@ -7,3 +8,14 @@ def image_method(func):
         return func(self, *args, **kwargs)
     setattr(ANTsImage, func.__name__, wrapper)
     return func
+
+
+def components_method(func):
+    @wraps(func) 
+    def wrapper(image, *args, **kwargs): 
+        if image.has_components:
+            return ants.merge_channels([func(img, *args, **kwargs) for img in ants.split_channels(image)],
+                                       channels_first=image.channels_first)
+        else:
+            return func(image, *args, **kwargs)
+    return wrapper

--- a/ants/ops/crop_image.py
+++ b/ants/ops/crop_image.py
@@ -7,10 +7,11 @@ __all__ = ['crop_image',
 
 
 import ants
-from ants.decorators import image_method
+from ants.decorators import image_method, components_method
 from ants.internal import get_lib_fn
 
 @image_method
+@components_method
 def crop_image(image, label_image=None, label=1):
     """
     Use a label image to crop a smaller ANTsImage from within a larger ANTsImage
@@ -40,11 +41,7 @@ def crop_image(image, label_image=None, label=1):
     >>> fi2 = ants.merge_channels([fi,fi])
     >>> cropped2 = ants.crop_image(fi2)
     >>> cropped = ants.crop_image(fi, fi, 100 )
-    """
-    if image.has_components:
-        return ants.merge_channels([crop_image(img, label_image, label) for img in ants.split_channels(image)],
-                                   channels_first=image.channels_first)
-        
+    """        
     inpixeltype = image.pixeltype
     ndim = image.dimension
     if image.pixeltype != 'float':
@@ -62,6 +59,7 @@ def crop_image(image, label_image=None, label=1):
 
 
 @image_method
+@components_method
 def crop_indices(image, lowerind, upperind):
     """
     Create a proper ANTsImage sub-image by indexing the image with indices. 
@@ -93,11 +91,7 @@ def crop_indices(image, lowerind, upperind):
     >>> cropped = ants.crop_indices( fi, (10,10), (100,100) )
     >>> cropped = ants.smooth_image( cropped, 5 )
     >>> decropped = ants.decrop_image( cropped, fi )
-    """
-    if image.has_components:
-        return ants.merge_channels([crop_indices(img, lowerind, upperind) for img in ants.split_channels(image)],
-                                   channels_first=image.channels_first)
-        
+    """ 
     inpixeltype = 'float'
     if image.pixeltype != 'float':
         inpixeltype = image.pixeltype
@@ -114,6 +108,7 @@ def crop_indices(image, lowerind, upperind):
     return ants_image
 
 @image_method
+@components_method
 def decrop_image(cropped_image, full_image):
     """
     The inverse function for `ants.crop_image`


### PR DESCRIPTION
There are many functions that do not natively support vector images in the C++ but can work in the Python code by splitting the image, applying the function to each component, and then merging the image back. Such functions look like this:

```python
@image_method
def crop_image(image):
   if image.has_components:
      return ants.merge_channels([crop_image(img) for img in ants.split_channels(image)])
   libfn = get_lib_fn('cropImage')
   return ants.from_pointer(libfn(image.pointer))
```

This PR removes that first if-statement by adding a decorator called `@components_method`. This decorator will let you add such split-apply-merge support to any function. It saves code and is more robust, so the function will now look like this:

```python
@image_method
@components_method
def crop_image(image):
   libfn = get_lib_fn('cropImage')
   return ants.from_pointer(libfn(image.pointer))
```

And now the function knows to do the split-apply-merge thing if the image has components.

NOTE that this should not be applied to functions that natively support component images in the C++ code (although it wont really hurt I think), but I think that is very few of them.