### PR TITLE
BUG: fix paste error from R, arg is type_of_transform

### DIFF
--- a/ants/segmentation/joint_label_fusion.py
+++ b/ants/segmentation/joint_label_fusion.py
@@ -132,7 +132,7 @@ def joint_label_fusion(
     >>> for i in range(len(ilist)):
     >>>     ilist[i] = ants.iMath(ilist[i],'Normalize')
     >>>     mytx = ants.registration(fixed=ref , moving=ilist[i] ,
-    >>>         typeofTransform = ('Affine') )
+    >>>         type_of_transform = ('Affine') )
     >>>     mywarpedimage = ants.apply_transforms(fixed=ref,moving=ilist[i],
     >>>             transformlist=mytx['fwdtransforms'])
     >>>     ilist[i] = mywarpedimage

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -93,7 +93,7 @@ class TestModule_joint_label_fusion(unittest.TestCase):
         for i in range(len(ilist)):
             ilist[i] = ants.iMath(ilist[i],'Normalize')
             mytx = ants.registration(fixed=ref , moving=ilist[i] ,
-                typeofTransform = ('Affine') )
+                type_of_transform = ('Affine') )
             mywarpedimage = ants.apply_transforms(fixed=ref,moving=ilist[i],
                     transformlist=mytx['fwdtransforms'])
             ilist[i] = mywarpedimage
@@ -121,7 +121,7 @@ class TestModule_joint_label_fusion(unittest.TestCase):
         for i in range(len(ilist)):
             ilist[i] = ants.iMath(ilist[i],'Normalize')
             mytx = ants.registration(fixed=ref , moving=ilist[i] ,
-                typeofTransform = ('Affine') )
+                type_of_transform = ('Affine') )
             mywarpedimage = ants.apply_transforms(fixed=ref,moving=ilist[i],
                     transformlist=mytx['fwdtransforms'])
             ilist[i] = mywarpedimage


### PR DESCRIPTION
A couple of places had the wrong name for the `type_of_transform` parameter to ants.registration.