### PR TITLE
fix typo in affine_initializer()

### DIFF
--- a/ants/registration/affine_initializer.py
+++ b/ants/registration/affine_initializer.py
@@ -13,7 +13,7 @@ def affine_initializer(fixed_image, moving_image, search_factor=20,
     """
     A multi-start optimizer for affine registration
     Searches over the sphere to find a good initialization for further
-    registration refinement, if needed.  This is a arapper for the ANTs
+    registration refinement, if needed.  This is a wrapper for the ANTs
     function antsAffineInitializer.
     
     ANTsR function: `affineInitializer`


### PR DESCRIPTION
Looks like there is a typo in the doc/comment for affine_initializer(), so I fixed it with this pull request.

Here is the change:

This is a **arapper** for  -> This is a **wrapper** for