### PR TITLE
COMP: downgrade numpy for arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "pandas",
     "pyyaml",
-    "numpy",
+    "numpy==2.0.1",
     "statsmodels",
     "webcolors",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "pandas",
     "pyyaml",
-    "numpy==2.0.1",
+    "numpy<=2.0.1",
     "statsmodels",
     "webcolors",
     "matplotlib",


### PR DESCRIPTION
Latest numpy and statsmodels don't play nicely together. Have to downgrade one or the other for now

https://github.com/statsmodels/statsmodels/issues/9333#issuecomment-2305438605