### PR TITLE
DISP:  Address pd warning.

### DIFF
--- a/ants/label/label_overlap_measures.py
+++ b/ants/label/label_overlap_measures.py
@@ -40,6 +40,6 @@ def label_overlap_measures(source_image, target_image):
     libfn = get_lib_fn("labelOverlapMeasures%iD" % source_image_int.dimension)
     df = libfn(source_image_int.pointer, target_image_int.pointer)
     df = pd.DataFrame(df)
-    df.Label[0] = "All"
-
+    with pd.option_context('mode.chained_assignment', None):
+        df.Label[0] = "All"
     return df


### PR DESCRIPTION
One way of addressing the following warning:

```python
>>> meas = ants.label_overlap_measures(dkt, dkt_repaired)
/Users/ntustison/anaconda3/lib/python3.11/site-packages/ants/label/label_overlap_measures.py:43: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  df.Label[0] = "All"
```