### PR TITLE
DOC: remove reference to ants/lib which no longer exists

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,10 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
     # add package to local path
 sys.path.insert(0, os.path.abspath('../../'))
 autodoc_mock_imports = ['_tkinter', 'matplotlib']
+if on_rtd:
+    # replace lib __init__ with empty init file since RTD cant handle C++ extensions
+    os.makedirs('../../ants/lib', exist_ok=True)
+    shutil.copyfile('emptyinit.py', '../../ants/lib/__init__.py')
 
 import ants
 import numpy as np

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,10 +27,6 @@ on_rtd = os.environ.get('READTHEDOCS') == 'True'
     # add package to local path
 sys.path.insert(0, os.path.abspath('../../'))
 autodoc_mock_imports = ['_tkinter', 'matplotlib']
-if on_rtd:
-    # replace lib __init__ with empty init file since RTD cant handle C++ extensions
-    os.remove('../../ants/lib/__init__.py')
-    shutil.copyfile('emptyinit.py', '../../ants/lib/__init__.py')
 
 import ants
 import numpy as np


### PR DESCRIPTION
RTD builds have been failing for a while