### PR TITLE
DOC: initial transform option

### DIFF
--- a/ants/registration/registration.py
+++ b/ants/registration/registration.py
@@ -64,6 +64,7 @@ def registration(
 
     initial_transform : list of strings (optional)
         transforms to prepend. If None, a translation is computed to align the image centers of mass.
+        To use an identity transform, set this to 'Identity'.
 
     outprefix : string
         output will be named with this prefix.


### PR DESCRIPTION
Document this more clearly higher up the function usage. Arguably it should default to Identity if doing "SyN only", but that would put it out of sync with antsRegistrationSyN.sh.