### PR TITLE
Make precision (--float) configurable for registration

### DIFF
--- a/ants/registration/registration.py
+++ b/ants/registration/registration.py
@@ -42,6 +42,7 @@ def registration(
     multivariate_extras=None,
     restrict_transformation=None,
     smoothing_in_mm=False,
+    singleprecision=False,
     **kwargs
 ):
     """
@@ -151,6 +152,10 @@ def registration(
           transformations.
 
     smoothing_in_mm : boolean ; currently only impacts low dimensional registration
+
+    singleprecision : boolean
+        if True, use float32 for computations. This is useful for reducing memory
+        usage for large datasets, at the cost of precision.    
 
     kwargs : keyword args
         extra arguments
@@ -409,13 +414,13 @@ def registration(
     # initx = invertAntsrTransform( initx )
     # writeAntsrTransform( initx, tempTXfilename )
     # initx = tempTXfilename
-    moving = moving.clone("float")
-    fixed = fixed.clone("float")
+    output_pixel_type = 'float' if singleprecision else 'double'
+
     # NOTE: this may be better for general purpose applications: TBD
 #    moving = ants.iMath( moving.clone("float"), "Normalize" )
 #    fixed = ants.iMath( fixed.clone("float"), "Normalize" )
-    warpedfixout = moving.clone()
-    warpedmovout = fixed.clone()
+    warpedfixout = moving.clone(output_pixel_type)
+    warpedmovout = fixed.clone(output_pixel_type)
     f = get_pointer_string(fixed)
     m = get_pointer_string(moving)
     wfo = get_pointer_string(warpedfixout)
@@ -1348,7 +1353,7 @@ def registration(
         args.append("-g")
         args.append(restrict_transformationchar)
 
-    args.append("--float")
+    args.append('--float', str(int(singleprecision)))
     args.append("1")
     args.append("--write-composite-transform")
     args.append(write_composite_transform * 1)

--- a/ants/registration/registration.py
+++ b/ants/registration/registration.py
@@ -42,7 +42,7 @@ def registration(
     multivariate_extras=None,
     restrict_transformation=None,
     smoothing_in_mm=False,
-    singleprecision=False,
+    singleprecision=True,
     **kwargs
 ):
     """
@@ -356,6 +356,8 @@ def registration(
         synits = "x".join([str(ri) for ri in reg_iterations])
 
     inpixeltype = fixed.pixeltype
+    output_pixel_type = 'float' if singleprecision else 'double'
+
     tvTypes = [
         "TV[1]",
         "TV[2]",
@@ -414,7 +416,6 @@ def registration(
     # initx = invertAntsrTransform( initx )
     # writeAntsrTransform( initx, tempTXfilename )
     # initx = tempTXfilename
-    output_pixel_type = 'float' if singleprecision else 'double'
 
     # NOTE: this may be better for general purpose applications: TBD
 #    moving = ants.iMath( moving.clone("float"), "Normalize" )

--- a/ants/registration/registration.py
+++ b/ants/registration/registration.py
@@ -1354,7 +1354,7 @@ def registration(
         args.append("-g")
         args.append(restrict_transformationchar)
 
-    args.append('--float')
+    args.append("--float")
     args.append(str(int(singleprecision)))
     args.append("--write-composite-transform")
     args.append(write_composite_transform * 1)

--- a/ants/registration/registration.py
+++ b/ants/registration/registration.py
@@ -1353,8 +1353,8 @@ def registration(
         args.append("-g")
         args.append(restrict_transformationchar)
 
-    args.append('--float', str(int(singleprecision)))
-    args.append("1")
+    args.append('--float')
+    args.append(str(int(singleprecision)))
     args.append("--write-composite-transform")
     args.append(write_composite_transform * 1)
     if verbose:

--- a/ants/registration/registration.py
+++ b/ants/registration/registration.py
@@ -416,12 +416,13 @@ def registration(
     # initx = invertAntsrTransform( initx )
     # writeAntsrTransform( initx, tempTXfilename )
     # initx = tempTXfilename
-
+    moving = moving.clone(output_pixel_type)
+    fixed = fixed.clone(output_pixel_type)
     # NOTE: this may be better for general purpose applications: TBD
 #    moving = ants.iMath( moving.clone("float"), "Normalize" )
 #    fixed = ants.iMath( fixed.clone("float"), "Normalize" )
-    warpedfixout = moving.clone(output_pixel_type)
-    warpedmovout = fixed.clone(output_pixel_type)
+    warpedfixout = moving.clone()
+    warpedmovout = fixed.clone()
     f = get_pointer_string(fixed)
     m = get_pointer_string(moving)
     wfo = get_pointer_string(warpedfixout)


### PR DESCRIPTION
Adds the option to configure `--float` in `ants.registration`. This feature already exists for `ants.apply_transforms`.