### PR TITLE
Fix mac wheels

### DIFF
--- a/.github/workflows/wheels_faster.yml
+++ b/.github/workflows/wheels_faster.yml
@@ -14,28 +14,28 @@ jobs:
           # Have to specify python version twice so that the same python is used to build and test
           # Need to quote decimal versions as string to avoid the "Norway problem"
 
-          # Windows 64-bit
-          - os: windows-latest
-            python: '3.11'
-            cibw_python: 311
-            platform_id: win_amd64
+          # Windows 64-bit - broken due to ITK issues
+        #   - os: windows-latest
+        #     python: '3.12'
+        #     cibw_python: 312
+        #     platform_id: win_amd64
 
           # Linux 64-bit
           - os: ubuntu-latest
-            python: '3.11'
-            cibw_python: 311
+            python: '3.12'
+            cibw_python: 312
             platform_id: manylinux_x86_64
 
           # macOS on Intel 64-bit
           - os: macos-13
-            python: '3.11'
-            cibw_python: 311
+            python: '3.12'
+            cibw_python: 312
             arch: x86_64
             platform_id: macosx_x86_64
 
           # macOS on Apple M1 64-bit, supported for Python 3.10 and later
           - os: macos-14
-            python: '3.11'
+            python: '3.12'
             cibw_python: 311
             arch: arm64
             platform_id: macosx_arm64
@@ -77,6 +77,14 @@ jobs:
         run: |
           macos_version=$(sw_vers -productVersion | awk -F '.' '{print $1".0"}')
           echo "MACOSX_DEPLOYMENT_TARGET=${macos_version}" >> $GITHUB_ENV
+          echo -n "clang version : "
+          clang --version
+          echo -n "xcode version : "
+          xcode-select -p
+          echo -n "cmake version : "
+          cmake --version
+          echo -n "env : "
+          env
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheels_faster.yml
+++ b/.github/workflows/wheels_faster.yml
@@ -36,7 +36,7 @@ jobs:
           # macOS on Apple M1 64-bit, supported for Python 3.10 and later
           - os: macos-14
             python: '3.12'
-            cibw_python: 311
+            cibw_python: 312
             arch: arm64
             platform_id: macosx_arm64
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.16.3...3.26)
 
 project(ants LANGUAGES CXX)
 
+# Set the macOS SDK root
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(CMAKE_OSX_SYSROOT "$(xcrun --show-sdk-path)")
+    message(STATUS "Using macOS SDK: ${CMAKE_OSX_SYSROOT}")
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Try to import all Python components potentially needed by nanobind
@@ -24,12 +30,6 @@ endif()
 set(ITK_DIR "./itkbuild")
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
-
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-  include_directories(/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1)
-  set(ENV{PATH} "$ENV{PATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1")
-  add_compile_options(-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1)
-endif()
 
 # ANTS
 add_library(antsUtilities STATIC src/antscore/antsUtilities.cxx src/antscore/antsCommandLineOption.cxx src/antscore/antsCommandLineParser.cxx src/antscore/ReadWriteData.cxx src/antscore/ANTsVersion.cxx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,12 @@ project(ants LANGUAGES CXX)
 
 # Set the macOS SDK root
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(CMAKE_OSX_SYSROOT "$(xcrun --show-sdk-path)")
+    execute_process(
+        COMMAND xcrun --show-sdk-path
+        OUTPUT_VARIABLE SDK_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(CMAKE_OSX_SYSROOT ${SDK_PATH})
     message(STATUS "Using macOS SDK: ${CMAKE_OSX_SYSROOT}")
 endif()
 

--- a/scripts/configure_ITK.sh
+++ b/scripts/configure_ITK.sh
@@ -38,25 +38,22 @@ cd ../
 echo "Dependency;GitTag" > ./data/softwareVersions.csv
 echo "ITK;${itktag}" >> ./data/softwareVersions.csv
 
-# if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-#  include_directories(/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1)
-##  set(ENV{PATH} "$ENV{PATH}:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1")
-#  add_compile_options(-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1)
-# endif()
-
 mkdir -p itkbuild
 cd itkbuild
 compflags=" -Wno-c++11-long-long -fPIC -O2 -DNDEBUG "
+osx_sysroot=""
 
 if [[ `uname` == 'Darwin' ]] ; then
-  compflags=" -Wno-c++11-long-long -fPIC -O2 -DNDEBUG -isystem /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 -stdlib=libc++ "
+  osx_sysroot=$(xcrun --sdk macosx --show-sdk-path)
 fi
+
 cmake \
 	-G"${ADD_G}" \
     -DITK_USE_SYSTEM_PNG=ON \
     -DCMAKE_SH:BOOL=OFF \
     -DCMAKE_BUILD_TYPE:STRING="${CMAKE_BUILD_TYPE}" \
-    -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -Wno-c++11-long-long -fPIC -O2 -DNDEBUG  "\
+    -DCMAKE_OSX_SYSROOT="${osx_sysroot}" \
+    -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} ${compflags}"\
     -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} ${compflags} "\
     -DITK_USE_GIT_PROTOCOL:BOOL=OFF \
     -DBUILD_SHARED_LIBS:BOOL=OFF \


### PR DESCRIPTION
Attempt to fix build errors by setting `CMAKE_OSX_SYSROOT` dynamically.

Hard-coded paths to `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk` break the runners, which use XCode rather than the command line tools.

@stnava would you mind testing if this solves your local build problems? Thanks