### PR TITLE
fix: vertical line (xyz-lines) in sagittal image of plot_ortho is flipped

### DIFF
--- a/ants/plotting/plot_ortho.py
+++ b/ants/plotting/plot_ortho.py
@@ -367,7 +367,7 @@ def plot_ortho(
         if xyz_lines:
             # add lines
             l = mlines.Line2D(
-                [yz_slice.shape[0] - xyz[1], yz_slice.shape[0] - xyz[1]],
+                [xyz[1], xyz[1]],
                 [xyz_pad, yz_slice.shape[0] - xyz_pad],
                 color=xyz_color,
                 alpha=xyz_alpha,


### PR DESCRIPTION
I have noticed that the vertical line of sagittal image in the `plot_ortho` was flipped.