### PR TITLE
No swap numpy dims

### DIFF
--- a/ants/core/ants_image_io.py
+++ b/ants/core/ants_image_io.py
@@ -99,7 +99,8 @@ def from_numpy(
     if best_dtype != data.dtype:
         data = data.astype(best_dtype)
 
-    img = _from_numpy(data.T.copy(), origin, spacing, direction, has_components, is_rgb)
+    # Be explicit about ordering of data - needs to be C-contiguous
+    img = _from_numpy(data.T.copy(order='C'), origin, spacing, direction, has_components, is_rgb)
     return img
 
 

--- a/src/itkPyBuffer.hxx
+++ b/src/itkPyBuffer.hxx
@@ -80,7 +80,6 @@ PyBuffer<TImage>
   memset(&pyBuffer, 0, sizeof(Py_buffer));
 
   SizeType size;
-  SizeType sizeFortran;
   SizeValueType numberOfPixels = 1;
 
   const void *                buffer;
@@ -114,14 +113,7 @@ PyBuffer<TImage>
     {
     item = PySequence_Fast_GET_ITEM(shapeseq,i);
     size[i] = (SizeValueType)PyLong_AsLong(item);
-    sizeFortran[dimension - 1 - i] = (SizeValueType)PyLong_AsLong(item);
     numberOfPixels *= size[i];
-    }
-
-  bool isFortranContiguous = false;
-  if( pyBuffer.strides != NULL && pyBuffer.itemsize == pyBuffer.strides[0] )
-    {
-    isFortranContiguous = true;
     }
 
   len = numberOfPixels*numberOfComponents*pixelSize;
@@ -139,14 +131,6 @@ PyBuffer<TImage>
   RegionType region;
   region.SetIndex( start );
   region.SetSize( size );
-  if( isFortranContiguous )
-    {
-    region.SetSize( sizeFortran );
-    }
-  else
-    {
-    region.SetSize( size );
-    }
 
   PointType origin;
   origin.Fill( 0.0 );

--- a/src/readImage.cxx
+++ b/src/readImage.cxx
@@ -36,7 +36,13 @@ AntsImage<ImageType> imageRead( std::string filename )
     return myImage;
 }
 
-
+/**
+ * Create an ANTsImage from a numpy array
+ *
+ * The data array must be C-contiguous, and ordered correctly
+ * See "4.1.7 Importing Image Data from a Buffer"
+ * https://itk.org/ITKSoftwareGuide/html/Book1/ITKSoftwareGuide-Book1ch4.html
+ */
 template <typename ImageType>
 AntsImage<ImageType> fromNumpy( nb::ndarray<nb::numpy> data, nb::tuple datashape )
 {

--- a/tests/test_core_ants_image_io.py
+++ b/tests/test_core_ants_image_io.py
@@ -350,5 +350,27 @@ class TestModule_ants_image_io(unittest.TestCase):
             ants.image_read(tmpfile)
 
 
+    def test_image_from_numpy_shape(self):
+        arr = np.random.randn(1,9,1).astype('float32')
+        img = ants.from_numpy(arr)
+        self.assertEqual(img.shape, arr.shape)
+        nptest.assert_allclose(img.numpy(), arr)
+
+        arr = np.random.randn(2,3,4).astype('float32')
+        img = ants.from_numpy(arr)
+        self.assertEqual(img.shape, arr.shape)
+        nptest.assert_allclose(img.numpy(), arr)
+
+        # Test special case where shape is (1,N), was getting transposed
+        arr = np.random.randn(1,9).astype('float32')
+        img = ants.from_numpy(arr)
+        self.assertEqual(img.shape, arr.shape)
+        nptest.assert_allclose(img.numpy(), arr)
+
+        arr = np.random.randn(9,1).astype('float32')
+        img = ants.from_numpy(arr)
+        self.assertEqual(img.shape, arr.shape)
+        nptest.assert_allclose(img.numpy(), arr)
+
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
Fixes #773 

I've been staring at this a while and I can't see a case where the "fortran contiguous" data would correctly read into an ITK image. It might have the right shape but it seems that the voxels would be wrong. 

In any case, as used, the code always copies the data into a C-contiguous array (the default).