### PR TITLE
ENH: Prevent attempts to iterate over antsImage

### DIFF
--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -567,6 +567,13 @@ class ANTsImage(object):
         else:
             arr.__setitem__(idx, value)
 
+
+    def __iter__(self):
+        # Do not allow iteration on ANTsImage. Builtin iteration, eg sum(), will generally be much slower
+        # than using numpy methods. We need to explicitly disallow it to prevent breaking object state.
+        raise TypeError("ANTsImage is not iterable. See docs for available functions, or use numpy.")
+
+
     def __repr__(self):
         if self.dimension == 3:
             s = 'ANTsImage ({})\n'.format(self.orientation)

--- a/tests/test_core_ants_image.py
+++ b/tests/test_core_ants_image.py
@@ -525,6 +525,13 @@ class TestClass_ANTsImage(unittest.TestCase):
             s = img.__repr__()
 
 
+    def test__iter__(self):
+        # Attempts to use __iter__ on an ANTsImage should raise a TypeError
+        img = self.imgs[0]
+        with self.assertRaises(TypeError):
+            for _ in img:
+                pass
+
 class TestModule_ants_image(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Because `antsImage.py` did not explicitly define `__iter__`, Python builtin iterator methods would call `__getitem__` directly, which breaks the object state.

Example:

```
im = ants.image_read('t1w.nii.gz')
im.sum() # works
sum(im) # error
im.sum() # now also errors
im[0,0,0] # now also errors
```

To prevent this, I added `__iter__` which raises a TypeError. Built-in iteration methods like sum() can be much slower than using numpy, so I didn't want to enable that.