### PR TITLE
CI: Build all the wheels weekly

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,8 @@
 name: build_wheels
 
 on:
-  schedule:
-    - cron: "0 5 * * *"
+  schedule: # Run weekly on Friday
+    - cron: '0 5 * * 5'
   release:
     types: [created]
   workflow_dispatch:

--- a/.github/workflows/wheels_faster.yml
+++ b/.github/workflows/wheels_faster.yml
@@ -1,6 +1,8 @@
 name: wheels_faster
 
 on:
+  schedule: # Run nightly except Fridays, when the more extensive wheel runs
+    - cron: "0 5 * * 0-4,6"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We now have quite a lot of wheels to build.

Switch to building on python=3.13 nightly, and build others only weekly.