### PR TITLE
COMP: Nanobind version limit for older Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2"]
+requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.2,<2.6"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
Looks like nanobind 2.6 requires python 3.12