### PR TITLE
CI: Send all wheels to pypi

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,10 +20,6 @@ jobs:
 
           # Windows 64-bit
           - os: windows-latest
-            python: '3.9'
-            cibw_python: 39
-            platform_id: win_amd64
-          - os: windows-latest
             python: '3.10'
             cibw_python: 310
             platform_id: win_amd64
@@ -67,11 +63,6 @@ jobs:
             platform_id: manylinux_x86_64
 
           # macOS on Intel 64-bit
-          - os: macos-13
-            python: '3.9'
-            cibw_python: 39
-            arch: x86_64
-            platform_id: macosx_x86_64
           - os: macos-13
             python: '3.10'
             cibw_python: 310
@@ -232,7 +223,7 @@ jobs:
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        if: ${{ (github.event_name == 'release') && (runner.os == 'Linux') }}
+        if: ${{ (github.event_name == 'release') }}
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Remove python 3.9 for Mac and Windows - trying to not run out of space again.