### PR TITLE
COMP: Allow modern numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "pandas",
     "pyyaml",
-    "numpy<=2.0.1",
+    "numpy",
     "statsmodels",
     "webcolors",
     "matplotlib",


### PR DESCRIPTION
Related to #813 

@neurolabusc reported not being able to install wheels requiring numpy 2.0.1 with Python 3.13 on OSX arm64. pip attempts to compile numpy but fails with an error about "string_fastsearch.h:132:5: error: no type named 'ptrdiff_t’".

Looks like others have had similar problems on Python 3.13.

I ran a test and we can install numpy 2.3 for all platforms, and all the tests run fine.