### PR TITLE
COMP: don't use latest scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "matplotlib",
     "Pillow",
     "requests",
-    "scikit-learn"
+    "scikit-learn",
+    "scipy<1.16"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ webcolors
 matplotlib
 Pillow
 scikit-learn
+scipy<1.16


### PR DESCRIPTION
statsmodels needs scipy < 1.16 for now. This will be fixed later