### PR TITLE
Pypi workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -208,25 +208,40 @@ jobs:
           artifacts: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish prep
-        if: ${{ (github.event_name == 'release') }}
+  publish:
+    name: Publish all wheels and sdist to PyPI
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'release') }}
+    needs:
+      - build_wheels
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
+        name: Install Python host for cibuildwheel
+        with:
+          python-version: '3.13'
+      - uses: actions/download-artifact@v4
+        with:
+          path: downloaded_artifacts
+      - name: Move wheels to dist/ root
         run: |
-          mywhl=`find ~/ -name "antspyx*.whl"`
-          extrawheeldir=`dirname $mywhl`
-          wheeldirx=`dirname $extrawheeldir`
-          wheeldir=`dirname $wheeldirx`
-          wheeldir=${wheeldir}/dist
-          mkdir -p $wheeldir
-          echo $wheeldir
-          mv $mywhl $wheeldir
-          rm -r -f $extrawheeldir $wheeldirx
-
-      - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        if: ${{ (github.event_name == 'release') }}
+            mkdir -p dist
+            find downloaded_artifacts -type f -name "*.whl" -exec mv {} dist/ \;
+      - name: Build sdist
+        run: |
+            python -m pip install --upgrade build
+            python -m build --sdist --outdir dist
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verify_metadata: false
-          skip_existing: true
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          verify-metadata: true
+          skip-existing: true
+          attestations: false
           verbose: true
+

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -233,12 +233,11 @@ jobs:
         run: |
             python -m pip install --upgrade build
             python -m build --sdist --outdir dist
-      - name: Publish to Test PyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: dist/
           verify-metadata: true
           skip-existing: true


### PR DESCRIPTION
Push sdist and wheels for all platforms in one go. Use job dependency so partial releases don't happen again