### PR TITLE
fix: setting incorrect direction raises descriptive error

### DIFF
--- a/ants/core/ants_image.py
+++ b/ants/core/ants_image.py
@@ -201,7 +201,7 @@ class ANTsImage(object):
         if not isinstance(new_direction, np.ndarray):
             raise ValueError('arg must be np.ndarray or tuple or list')
         if len(new_direction) != self.dimension:
-            raise ValueError('must give a origin value for each dimension (%i)' % self.dimension)
+            raise ValueError('must give a direction value for each dimension (%i)' % self.dimension)
 
         get_lib_fn('setDirection')(self.pointer, new_direction)
 


### PR DESCRIPTION
Before, setting a direction with the wrong number of dimensions raised an error that said the origin had incorrect dimension. I have changed the error message to correctly reference the direction.

fixes #845