### PR TITLE
COMP: Update ITK, ANTs, roll back numpy changes

### DIFF
--- a/ants/deeplearn/randomly_transform_image_data.py
+++ b/ants/deeplearn/randomly_transform_image_data.py
@@ -48,7 +48,7 @@ def randomly_transform_image_data(reference_image,
         Number of simulated output image sets.
 
     transform_type : string
-        One of the following options: "translation", "rotation", "rigid", "scaleShear",
+        One of the following options: "translation", "rotation", "rigid", "scaleShear", 
         "affine", "deformation", "affineAndDeformation".
 
     sd_affine : float
@@ -113,13 +113,13 @@ def randomly_transform_image_data(reference_image,
 
         if transform_type == 'translation':
             random_epsilon[:(len(identity_parameters) - image.dimension)] = 0
-        elif transform_type == "rotation":
+        elif transform_type == "rotation": 
             random_epsilon[(len(identity_parameters) - image.dimension):] = 0
 
         random_parameters = identity_parameters + random_epsilon
         random_matrix = np.reshape(
             random_parameters[:(len(identity_parameters) - image.dimension)],
-            shape=(image.dimension, image.dimension))
+            newshape=(image.dimension, image.dimension))
         decomposition = ants.polar_decomposition(random_matrix)
 
         if transform_type == "rotation" or transform_type == "rigid":
@@ -130,7 +130,7 @@ def randomly_transform_image_data(reference_image,
             random_matrix = decomposition['P']
 
         random_parameters[:(len(identity_parameters) - image.dimension)] = \
-            np.reshape(random_matrix, shape=(len(identity_parameters) - image.dimension))
+            np.reshape(random_matrix, newshape=(len(identity_parameters) - image.dimension))
         ants.set_ants_transform_parameters(transform, random_parameters)
         return(transform)
 

--- a/ants/label/label_image_centroids.py
+++ b/ants/label/label_image_centroids.py
@@ -74,7 +74,7 @@ def label_image_centroids(image, physical=False, convex=True, verbose=False):
             for j in range(len(xci)):
                 dist[j] = np.mean(np.sqrt((xci[j] - xci)**2 + (yci[j] - yci)**2 + (zci[j] - zci)**2))
 
-            mid = np.argmin(dist)
+            mid = np.where(dist==np.min(dist))
             xc[lab_idx] = xci[mid]
             yc[lab_idx] = yci[mid]
             zc[lab_idx] = zci[mid]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
     "pandas",
     "pyyaml",
-    "numpy",
+    "numpy<2.4.0",
     "statsmodels",
     "webcolors",
     "matplotlib",

--- a/scripts/configure_ANTs.bat
+++ b/scripts/configure_ANTs.bat
@@ -11,8 +11,8 @@ COPY data\* %USERPROFILE%\.antspy
 
 :: clone ANTs and move all files into library directory
 SET antsgit=https://github.com/ANTsX/ANTs.git
-:: ANTs 2025-07-08 tensor I/O fixes
-SET antstag=0fc81b7939f08e12500e3066b23697d04af9fe08
+:: ANTs 2.6.5 2026-01-14
+SET antstag=fdce4d2f84b60ac75d7e45aafe18488b1f9f5303
 echo "ANTS;%antstag%" REM UNKNOWN: {"type":"Redirect","op":{"text":">>","type":"dgreat"},"file":{"text":"./data/softwareVersions.csv","type":"Word"}}
 cd src
 echo "123"

--- a/scripts/configure_ANTs.sh
+++ b/scripts/configure_ANTs.sh
@@ -13,7 +13,7 @@ cp data/* ~/.antspy/
 # clone ANTs and move all files into library directory
 
 antsgit=https://github.com/ANTsX/ANTs.git
-antstag=0fc81b7939f08e12500e3066b23697d04af9fe08 # tensor I/O fix 2025-07-08
+antstag=fdce4d2f84b60ac75d7e45aafe18488b1f9f5303 # 2.6.5 2026-01-14
 echo "ANTS;${antstag}" >> ./data/softwareVersions.csv
 
 cd src # go to lib dir

--- a/scripts/configure_ITK.bat
+++ b/scripts/configure_ITK.bat
@@ -4,8 +4,8 @@
 SET CMAKE_BUILD_TYPE=Release
 
 SET itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-:: 5.4.3
-SET itktag=0913f2a962d28eb5725a50a17304c4652ca6cfdc
+:: 5.4.5
+SET itktag=f51594ad88194a72cdc06a314dafff709fcdc2e9
 
 :: if there is a directory but no git, remove it
 if exist itksource\ (

--- a/scripts/configure_ITK.sh
+++ b/scripts/configure_ITK.sh
@@ -14,7 +14,7 @@ if [[ "$TRAVIS" == "true" ]] ; then
 fi
 
 itkgit=https://github.com/InsightSoftwareConsortium/ITK.git
-itktag=0913f2a962d28eb5725a50a17304c4652ca6cfdc # 5.4.3
+itktag=f51594ad88194a72cdc06a314dafff709fcdc2e9 # 5.4.5
 # if there is a directory but no git, remove it
 if [[ -d itksource ]]; then
     if [[ ! -d itksource/.git ]]; then


### PR DESCRIPTION
Require numpy < 2.4 for now.

Eventually we will update ITK to v6, at which point we should probably drop support for python 3.8 and 3.9. This will allow us to update numpy and scipy

Also would be a good point to update manylinux and cibuildwheel