### PR TITLE
Remove explicit dependency from old scipy version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ dependencies = [
     "matplotlib",
     "Pillow",
     "requests",
-    "scikit-learn",
-    "scipy<1.16"
+    "scikit-learn"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ webcolors
 matplotlib
 Pillow
 scikit-learn
-scipy<1.16


### PR DESCRIPTION
Revert https://github.com/ANTsX/ANTsPy/pull/825 / https://github.com/ANTsX/ANTsPy/commit/a6c2174f8e6a57066c621077d7aa487775d6b649 as statsmodels has been fixed in [version 0.14.5](https://github.com/statsmodels/statsmodels/releases/tag/v0.14.5), released in July 2025.