### PR TITLE
CI: Update actions versions

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: antsx/antspy
       -
@@ -56,11 +56,11 @@ jobs:
             echo "DOCKER_TAGS=${DOCKER_TAGS}" >> "$GITHUB_ENV"
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v7
       -
         name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/ci-pytest.yml
+++ b/.github/workflows/ci-pytest.yml
@@ -23,16 +23,17 @@ jobs:
         shell: bash -el {0}
     steps:
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5
         with:
             channels: conda-forge
+            conda-remove-defaults: true
             miniforge-version: latest
             python-version: ${{ env.python_version }}
             auto-update-conda: true
             activate-environment: antspy-env
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
             path: antspy-pr
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
 
       - name: Install package
         run: python -m pip install .

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -212,6 +212,7 @@ jobs:
       - name: Upload debug artifacts on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
+        with:
           name: debug-${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: |
             wheelhouse/**
@@ -219,7 +220,8 @@ jobs:
             ./**/CMakeCache.txt
           if-no-files-found: warn
 
-      - uses: actions/upload-artifact@v7
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -211,8 +211,7 @@ jobs:
 
       - name: Upload debug artifacts on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v6
-        with:
+        uses: actions/upload-artifact@v7
           name: debug-${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: |
             wheelhouse/**
@@ -220,7 +219,7 @@ jobs:
             ./**/CMakeCache.txt
           if-no-files-found: warn
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl
@@ -228,7 +227,7 @@ jobs:
       - name: Upload release asset
         # Previously was using actions/upload-release-asset@v1 , but this had some
         # errors with large files
-        uses: ncipollo/release-action@v1.11.1
+        uses: ncipollo/release-action@v1.21.0
         if: ${{ github.event_name == 'release' }}
         with:
           allowUpdates: true

--- a/.github/workflows/wheels_faster.yml
+++ b/.github/workflows/wheels_faster.yml
@@ -162,7 +162,8 @@ jobs:
             ./**/CMakeCache.txt
           if-no-files-found: warn
 
-      - uses: actions/upload-artifact@v7
+      - name: Upload wheels
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl

--- a/.github/workflows/wheels_faster.yml
+++ b/.github/workflows/wheels_faster.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload debug artifacts on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: debug-${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: |
@@ -162,7 +162,7 @@ jobs:
             ./**/CMakeCache.txt
           if-no-files-found: warn
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PACKAGE_NAME }}-${{ env.PACKAGE_VERSION }}-cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}
           path: ./wheelhouse/cp${{ matrix.cibw_python }}-${{ matrix.platform_id }}/*.whl


### PR DESCRIPTION
Solves most warnings about node.js, but still need a replacement for seemingly abandonded Windows build action