### PR TITLE
CI: add Linux ARM64 wheel build support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -118,6 +118,28 @@ jobs:
             arch: arm64
             platform_id: macosx_arm64
 
+          # Linux ARM64 (aarch64) via native ARM runner
+          - os: ubuntu-24.04-arm
+            python: '3.10'
+            cibw_python: 310
+            arch: aarch64
+            platform_id: manylinux_aarch64
+          - os: ubuntu-24.04-arm
+            python: '3.11'
+            cibw_python: 311
+            arch: aarch64
+            platform_id: manylinux_aarch64
+          - os: ubuntu-24.04-arm
+            python: '3.12'
+            cibw_python: 312
+            arch: aarch64
+            platform_id: manylinux_aarch64
+          - os: ubuntu-24.04-arm
+            python: '3.13'
+            cibw_python: 313
+            arch: aarch64
+            platform_id: manylinux_aarch64
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -182,6 +204,7 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: |
             python -m pip install cmake ninja setuptools SimpleITK nibabel
 
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 
           CIBW_ENVIRONMENT_MACOS: |

--- a/.github/workflows/wheels_faster.yml
+++ b/.github/workflows/wheels_faster.yml
@@ -44,6 +44,13 @@ jobs:
             arch: arm64
             platform_id: macosx_arm64
 
+          # Linux ARM64 (aarch64) via native ARM runner
+          - os: ubuntu-24.04-arm
+            python: '3.13'
+            cibw_python: 313
+            arch: aarch64
+            platform_id: manylinux_aarch64
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -115,6 +122,7 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: |
             python -m pip install cmake ninja setuptools SimpleITK nibabel
 
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 
           CIBW_ENVIRONMENT_MACOS: |


### PR DESCRIPTION
Add Linux ARM64 (aarch64) wheel build support to CI workflows, enabling automatic delivery of `manylinux_aarch64` wheels.

This change addresses the growing adoption of the ARM64 architecture in server and cloud computing environments. By providing native wheels, we improve the deployment and user experience on these increasingly common platforms (e.g., AWS Graviton and other ARM-based servers).

The implementation utilizes GitHub's native ARM64 runners (`ubuntu-24.04-arm`).

**Changes**

*   **wheels.yml**: Added matrix entries for Python 3.10–3.13 on `ubuntu-24.04-arm` to build release wheels for the `manylinux_aarch64` platform.
*   **wheels_faster.yml**: Mirrored the change for Python 3.13 in the PR-triggered workflow to ensure ongoing compatibility.
*   Set `CIBW_ARCHS_LINUX: ${{ matrix.arch }}` in both workflows to instruct `cibuildwheel` to target the correct architecture on the native runner.

**Verification**

All CI jobs passed, and the produced wheels were successfully tested against the project's existing test suite. No compatibility issues were observed with underlying build dependencies during the CI run.

*   [CI run link](https://github.com/plasma-blue/ANTsPy/actions/runs/29682433126)

Each aarch64 job completed in approximately 27 minutes, a duration comparable to the existing x86_64 jobs.

**Impact**

*   **No increase in CI wall-clock time**: ARM64 builds run in parallel with other matrix entries, and the overall CI duration remains limited by the `macos` runner pool.
*   **No cost**: GitHub-hosted ARM runners are free for public repositories.
*   **No code changes**: This is a pure CI configuration update. The project's existing build scripts and source code required no modification.